### PR TITLE
Wrap `oct_cli_sdk` functions into `Client` struct

### DIFF
--- a/crates/oct-cli/src/main.rs
+++ b/crates/oct-cli/src/main.rs
@@ -27,9 +27,13 @@ enum Commands {
 
 #[derive(Parser)]
 struct CommandArgs {
-    /// Path to the state file
+    /// Path to the infra state file
     #[clap(long, default_value = "./state.json")]
     state_file_path: String,
+
+    /// Path to the user state file
+    #[clap(long, default_value = "./user_state.json")]
+    user_state_file_path: String,
 
     /// Path to the Dockerfile
     #[clap(long, default_value = ".")]
@@ -46,11 +50,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let cli = Cli::parse();
 
-    let state_file_path = "./state.json";
-    let user_state_file_path = "./user_state.json";
-
     match &cli.command {
-        Commands::Deploy(_args) => {
+        Commands::Deploy(args) => {
             // Get project config
             let config = config::Config::new(None)?;
 
@@ -76,64 +77,59 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             // Save to state file
             let instance_state = state::Ec2InstanceState::new(&instance).await;
             let json_data = serde_json::to_string_pretty(&instance_state)?;
-            fs::write(state_file_path, json_data)?;
+            fs::write(&args.state_file_path, json_data)?;
 
             log::info!("Waiting for oct-ctl to be ready");
             tokio::time::sleep(std::time::Duration::from_secs(60)).await;
 
-            match instance.public_ip {
-                Some(public_ip) => {
-                    for service in config.project.services {
-                        log::info!("Running container for service: {}", service.name);
+            let public_ip = instance.public_ip.ok_or("Public IP not found")?;
 
-                        let response = oct_ctl_sdk::run_container(
-                            service.name.to_string(),
-                            service.image.to_string(),
-                            service.external_port.to_string(),
-                            service.internal_port.to_string(),
-                            public_ip.to_string(),
-                        )
-                        .await?;
+            let oct_ctl_client = oct_ctl_sdk::Client::new(public_ip.clone());
 
-                        log::info!("Response: {}", response.text().await?);
-                        log::info!(
-                            "Service is available at http://{}:{}",
-                            public_ip,
-                            service.external_port
-                        );
+            for service in config.project.services {
+                log::info!("Running container for service: {}", service.name);
 
-                        // Save service to user state file
-                        let deployed_service = user_state::UserState::new(
-                            service.name.to_string(),
-                            public_ip.to_string(),
-                        );
-                        fs::write(
-                            user_state_file_path,
-                            serde_json::to_string_pretty(&deployed_service)?,
-                        )?;
-                        log::info!(
-                            "Service: {} - saved to user state file",
-                            service.name.to_string()
-                        );
-                    }
-                }
-                None => {
-                    log::error!("Public IP not found");
-                }
+                let response = oct_ctl_client
+                    .run_container(
+                        service.name.to_string(),
+                        service.image.to_string(),
+                        service.external_port.to_string(),
+                        service.internal_port.to_string(),
+                    )
+                    .await?;
+
+                log::info!("Response: {}", response.text().await?);
+                log::info!(
+                    "Service is available at http://{}:{}",
+                    public_ip,
+                    service.external_port
+                );
+
+                // Save service to user state file
+                let deployed_service =
+                    user_state::UserState::new(service.name.to_string(), public_ip.to_string());
+                fs::write(
+                    &args.user_state_file_path,
+                    serde_json::to_string_pretty(&deployed_service)?,
+                )?;
+                log::info!(
+                    "Service: {} - saved to user state file",
+                    service.name.to_string()
+                );
             }
         }
-        Commands::Destroy(_args) => {
+        Commands::Destroy(args) => {
             // Load instance from state file
-            let json_data = fs::read_to_string(state_file_path).expect("Unable to read file");
+            let json_data = fs::read_to_string(&args.state_file_path).expect("Unable to read file");
             let state: state::Ec2InstanceState = serde_json::from_str(&json_data)?;
 
             // Create EC2 instance from state
             let mut instance = state.new_from_state().await?;
 
             // Check if user state file exists
-            if std::path::Path::new(user_state_file_path).exists() {
+            if std::path::Path::new(&args.user_state_file_path).exists() {
                 // Load service from user state file
-                let service_json_data = fs::read_to_string(user_state_file_path)
+                let service_json_data = fs::read_to_string(&args.user_state_file_path)
                     .expect("Unable to read user state file");
                 let user_state: user_state::UserState = serde_json::from_str(&service_json_data)?;
 
@@ -143,16 +139,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     user_state.service_name
                 );
 
-                let response = oct_ctl_sdk::remove_container(
-                    user_state.service_name.to_string(),
-                    user_state.public_ip.to_string(),
-                )
-                .await?;
+                let oct_ctl_client = oct_ctl_sdk::Client::new(user_state.public_ip);
 
-                log::info!("Response: {}", response.text().await?);
+                let response = oct_ctl_client
+                    .remove_container(user_state.service_name)
+                    .await?;
 
                 // Remove service from user state file
-                fs::remove_file(user_state_file_path).expect("Unable to remove file");
+                fs::remove_file(&args.user_state_file_path).expect("Unable to remove file");
                 log::info!("Service removed from user state file");
             } else {
                 log::warn!("User state file not found or no containers are running");
@@ -164,7 +158,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             log::info!("Instance destroyed");
 
             // Remove instance from state file
-            fs::remove_file(state_file_path).expect("Unable to remove file");
+            fs::remove_file(&args.state_file_path).expect("Unable to remove file");
 
             log::info!("Instance removed from state file");
         }

--- a/crates/oct-cli/src/oct_ctl_sdk.rs
+++ b/crates/oct-cli/src/oct_ctl_sdk.rs
@@ -1,62 +1,64 @@
+/// TODO: Generate this from `oct-ctl`'s OpenAPI spec
 use reqwest::Response;
 use std::collections::HashMap;
 
-pub(crate) async fn run_container(
-    name: String,
-    image: String,
-    external_port: String,
-    internal_port: String,
+pub(crate) struct Client {
     public_ip: String,
-) -> Result<Response, reqwest::Error> {
-    let client = reqwest::Client::new();
-
-    let mut map = HashMap::new();
-    map.insert("name", name.as_str());
-    map.insert("image", image.as_str());
-    map.insert("external_port", external_port.as_str());
-    map.insert("internal_port", internal_port.as_str());
-
-    let response = client
-        .post(format!(
-            "http://{public_ip}:31888/run-container",
-            public_ip = public_ip
-        ))
-        .header("Content-Type", "application/json")
-        .header("Accept", "application/json")
-        .body(serde_json::to_string(&map).unwrap())
-        .send()
-        .await?;
-
-    if response.status().is_success() {
-        Ok(response)
-    } else {
-        response.error_for_status()
-    }
 }
 
-pub(crate) async fn remove_container(
-    name: String,
-    public_ip: String,
-) -> Result<Response, reqwest::Error> {
-    let client = reqwest::Client::new();
+impl Client {
+    pub(crate) fn new(public_ip: String) -> Self {
+        Self { public_ip }
+    }
 
-    let mut map = HashMap::new();
-    map.insert("name", name.as_str());
+    pub(crate) async fn run_container(
+        &self,
+        name: String,
+        image: String,
+        external_port: String,
+        internal_port: String,
+    ) -> Result<Response, reqwest::Error> {
+        let client = reqwest::Client::new();
 
-    let response = client
-        .post(format!(
-            "http://{public_ip}:31888/remove-container",
-            public_ip = public_ip
-        ))
-        .header("Content-Type", "application/json")
-        .header("Accept", "application/json")
-        .body(serde_json::to_string(&map).unwrap())
-        .send()
-        .await?;
+        let mut map = HashMap::new();
+        map.insert("name", name.as_str());
+        map.insert("image", image.as_str());
+        map.insert("external_port", external_port.as_str());
+        map.insert("internal_port", internal_port.as_str());
 
-    if response.status().is_success() {
-        Ok(response)
-    } else {
-        response.error_for_status()
+        let response = client
+            .post(format!("http://{}:31888/run-container", self.public_ip))
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .body(serde_json::to_string(&map).unwrap())
+            .send()
+            .await?;
+
+        if response.status().is_success() {
+            Ok(response)
+        } else {
+            response.error_for_status()
+        }
+    }
+
+    pub(crate) async fn remove_container(&self, name: String) -> Result<Response, reqwest::Error> {
+        let client = reqwest::Client::new();
+
+        let mut map = HashMap::new();
+        map.insert("name", name.as_str());
+
+        let response = client
+            .post(format!("http://{}:31888/remove-container", self.public_ip))
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .body(serde_json::to_string(&map).unwrap())
+            .send()
+            .await?;
+
+        if response.status().is_success() {
+            Ok(response)
+        } else {
+            response.error_for_status()
+        }
     }
 }


### PR DESCRIPTION
Refactors `oct-ctl` SDK into a client struct and adds state file path CLI arguments

- Adds `--state-file-path` and `--user-state-file-path` CLI arguments
- Creates `Client` struct for `oct-ctl` SDK to handle HTTP requests
- Improves error handling for missing public IP
- Removes hardcoded state file paths