### PR TITLE
Run postsubmit workflow on any pull_request

### DIFF
--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "**" ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
### TL;DR
Updated GitHub Actions workflow to run on all branches during pull requests

### What changed?
Modified the branch trigger in postsubmit.yml from `main` to `*` for pull requests, allowing the workflow to run on all branches

### How to test?
1. Create a new branch
2. Open a pull request
3. Verify that the GitHub Actions workflow triggers automatically

### Why make this change?
To ensure consistent CI/CD checks across all branches during development, not just when targeting the main branch. This helps catch issues earlier in the development process.