### PR TITLE
Add codecov badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Actions status](https://github.com/21inchLingcod/opencloudtool/actions/workflows/postsubmit.yml/badge.svg)](https://github.com/21inchLingcod/opencloudtool/actions)
+[![codecov](https://codecov.io/github/opencloudtool/opencloudtool/graph/badge.svg?token=J8XGW0T1LC)](https://codecov.io/github/opencloudtool/opencloudtool)
 
 # Open Cloud Tool
 


### PR DESCRIPTION
### TL;DR
Added Codecov badge to README.md

### What changed?
Added a Codecov badge that displays the current code coverage status from codecov.io

### How to test?
1. View the README.md file
2. Verify the Codecov badge appears and links to the correct coverage report
3. Click the badge to ensure it redirects to codecov.io

### Why make this change?
Provides immediate visibility into the project's code coverage metrics, helping developers and contributors quickly assess the testing status of the codebase