### PR TITLE
Add codecov uploading step in postsubmit workflow

### DIFF
--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -68,4 +68,11 @@ jobs:
       run: cargo test --verbose
 
     - name: Generate coverage report
-      run: grcov . --binary-path ./target/debug/deps/ -s . -t markdown --branch --ignore-not-existing --ignore '../*' --ignore "/*"
+      run: grcov . --binary-path ./target/debug/deps/ -s . -t cobertura-pretty --branch --ignore-not-existing --ignore '../*' --ignore "/*" -o ./coverage.xml
+
+    - name: Upload coverage report
+      uses: codecov/codecov-action@v5
+      with:
+        files: ./coverage.xml
+        token: ${{ secrets.CODECOV_TOKEN }}
+        slug: opencloudtool/opencloudtool


### PR DESCRIPTION
### TL;DR
Added Codecov integration to the CI pipeline for code coverage reporting.

### What changed?
- Modified grcov output format from markdown to cobertura-pretty
- Added coverage report upload step using codecov/codecov-action
- Configured Codecov repository settings with authentication token

### How to test?
1. Push changes to any branch
2. Verify that the GitHub Actions workflow completes successfully
3. Check that coverage reports appear in Codecov dashboard
4. Confirm coverage data is properly linked to the repository

### Why make this change?
Integrating Codecov provides better visibility into test coverage metrics, enables coverage tracking over time, and helps maintain code quality standards through automated coverage reporting.