### PR TITLE
Remove `cancel-in-progress` from postsubmit workflow

### DIFF
--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -9,10 +9,8 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
-# Add this concurrency configuration
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
### TL;DR
Removed the `cancel-in-progress` flag from the GitHub Actions workflow concurrency settings.

### What changed?
Removed the `cancel-in-progress: true` configuration from the postsubmit workflow's concurrency group settings, while maintaining the group definition based on workflow and ref.

### How to test?
1. Push multiple commits in quick succession to a branch
2. Verify that GitHub Actions does not cancel in-progress workflow runs
3. Confirm that concurrent runs are still grouped by workflow and ref

### Why make this change?
Allowing concurrent workflow runs to complete rather than canceling them ensures that all commits are properly validated, preventing potential issues from being missed due to canceled builds.