### PR TITLE
Remove unused dependencies using `machete`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,17 +102,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.85"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,7 +126,7 @@ dependencies = [
  "aws-sdk-sts",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json 0.61.2",
+ "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -201,7 +190,7 @@ dependencies = [
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json 0.61.2",
+ "aws-smithy-json",
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -209,28 +198,6 @@ dependencies = [
  "aws-smithy-xml",
  "aws-types",
  "fastrand",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-ecr"
-version = "1.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cdad20ef3006b80d50fc8717fdb1eb3482004ad16016ebe209b690fc35dd5c"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json 0.60.7",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -247,7 +214,7 @@ dependencies = [
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json 0.61.2",
+ "aws-smithy-json",
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -270,7 +237,7 @@ dependencies = [
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json 0.61.2",
+ "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -292,7 +259,7 @@ dependencies = [
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json 0.61.2",
+ "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -314,7 +281,7 @@ dependencies = [
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json 0.61.2",
+ "aws-smithy-json",
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -379,15 +346,6 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "tracing",
-]
-
-[[package]]
-name = "aws-smithy-json"
-version = "0.60.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4683df9469ef09468dad3473d129960119a0d3593617542b7d52086c8486f2d6"
-dependencies = [
- "aws-smithy-types",
 ]
 
 [[package]]
@@ -1616,7 +1574,6 @@ dependencies = [
  "predicates",
  "reqwest",
  "serde",
- "serde_derive",
  "serde_json",
  "tempfile",
  "tokio",
@@ -1627,19 +1584,14 @@ dependencies = [
 name = "oct-cloud"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "aws-config",
  "aws-sdk-ec2",
- "aws-sdk-ecr",
  "aws-sdk-iam",
  "base64 0.22.1",
- "env_logger",
  "log",
  "mockall",
  "serde",
- "serde_json",
  "tokio",
- "uuid",
 ]
 
 [[package]]
@@ -1647,10 +1599,8 @@ name = "oct-ctl"
 version = "0.1.0"
 dependencies = [
  "axum",
- "env_logger",
  "log",
  "mockall",
- "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -2688,9 +2638,6 @@ name = "uuid"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "744018581f9a3454a9e15beb8a33b017183f1e7c0cd170232a2d1453b23a51c4"
-dependencies = [
- "getrandom",
-]
 
 [[package]]
 name = "valuable"

--- a/crates/oct-cli/Cargo.toml
+++ b/crates/oct-cli/Cargo.toml
@@ -11,7 +11,6 @@ clap = { workspace = true }
 tokio = { workspace = true }
 predicates = { workspace = true }
 serde = { workspace = true }
-serde_derive = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 log = { workspace = true }

--- a/crates/oct-cloud/Cargo.toml
+++ b/crates/oct-cloud/Cargo.toml
@@ -4,19 +4,14 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-async-trait = { workspace = true }
 aws-config = { workspace = true }
 aws-sdk-ec2 = { workspace = true }
-aws-sdk-ecr = { workspace = true }
 aws-sdk-iam = { workspace = true }
 base64 = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 mockall = { workspace = true }
-uuid = { workspace = true, features = ["v4"] }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
 log = { workspace = true }
-env_logger = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/oct-ctl/Cargo.toml
+++ b/crates/oct-ctl/Cargo.toml
@@ -7,10 +7,8 @@ edition = "2021"
 axum = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-env_logger = { workspace = true }
 log = { workspace = true }
 mockall = { workspace = true }
-reqwest = { workspace = true, features = ["json"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tower-http = { workspace = true, features = ["trace"] }
 tower = { workspace = true }


### PR DESCRIPTION
### TL;DR
Removed unused dependencies across multiple crates to reduce the project's dependency footprint.

### What changed?
- Removed dependencies:
  - `async-trait`
  - `aws-sdk-ecr`
  - `env_logger`
  - `reqwest`
  - `serde_derive`
  - `serde_json` (from oct-cloud)
  - `uuid` (with v4 feature)
- Cleaned up AWS Smithy JSON version references
- Removed unused feature flags from remaining dependencies

### How to test?
1. Run `cargo build` to ensure all crates compile successfully
2. Execute the existing test suite to verify no functionality is broken
3. Verify that all core features continue to work as expected

### Why make this change?
Removing unused dependencies helps:
- Reduce compilation times
- Decrease the attack surface
- Minimize the project's overall complexity
- Improve maintenance by removing unnecessary code dependencies