### PR TITLE
Add `cargo machete` to postsubmit workflow

### DIFF
--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -57,6 +57,9 @@ jobs:
     - name: Run fmt
       run: cargo fmt --check
 
+    - name: Machete
+      uses: bnjbvr/cargo-machete@main
+
     - name: Run tests
       env:
         RUST_BACKTRACE: full


### PR DESCRIPTION
Added cargo-machete to the postsubmit workflow to detect unused dependencies

Closes #99

<!-- branch-stack -->

- `main`
  - \#103 :point\_left:
