### PR TITLE
Remove `localstack` service usage in postsubmit workflow

### DIFF
--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -17,20 +17,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    services:
-      localstack:
-        image: localstack/localstack
-        ports:
-          - 4566:4566
-        env:
-          SERVICES: ec2
-        options: >-
-          --name=localstack
-          --health-cmd="curl -sS http://localhost:4566/health || exit 1"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=3
-
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
### TL;DR
Removed Localstack service configuration from the postsubmit GitHub workflow.

### What changed?
Removed the Localstack service configuration block from the postsubmit.yml workflow file, which previously set up an EC2 service emulator running on port 4566 with health checks.

### How to test?
1. Verify that the GitHub workflow runs successfully without the Localstack service
2. Confirm that any tests or operations that previously depended on Localstack have been updated or are no longer needed

### Why make this change?
The Localstack service configuration appears to be unnecessary for the postsubmit workflow, suggesting that either:
- The EC2 service emulation is no longer required for tests
- The tests have been moved to a different workflow
- The testing strategy has changed to not require local AWS service emulation