### PR TITLE
Add "tip" tag creation for latest commits on push into main

### DIFF
--- a/.github/workflows/release-oct-ctl.yml
+++ b/.github/workflows/release-oct-ctl.yml
@@ -1,8 +1,12 @@
 name: Release oct-ctl
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows:
+      - Post-submit Checks
+    types:
+      - completed
+  
 
 env:
   CARGO_TERM_COLOR: always
@@ -17,7 +21,7 @@ permissions:
 
 jobs:
   build:
-
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.ref_name == 'main' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -37,7 +41,10 @@ jobs:
     - name: Build oct-ctl
       run: cargo build -p oct-ctl --release --verbose
 
-    - name: Upload oct-ctl binary to release
+    - name: Upload release
       env:
         GITHUB_TOKEN: ${{ github.TOKEN }}
-      run: gh release upload ${{github.event.release.tag_name}} target/release/oct-ctl
+      run: |
+        git tag -fa tip -m "Latest Continuous Release"
+        git push -f origin tip
+        gh release create tip target/release/oct-ctl --title "Latest Continuous Release" --notes "This is the latest build of oct-ctl." --target tip --prerelease --force

--- a/crates/oct-cloud/src/aws.rs
+++ b/crates/oct-cloud/src/aws.rs
@@ -310,7 +310,7 @@ impl Ec2Instance {
     curl \
         --output /home/ubuntu/oct-ctl \
         -L \
-        https://github.com/21inchLingcod/opencloudtool/releases/download/v0.0.7/oct-ctl \
+        https://github.com/21inchLingcod/opencloudtool/releases/download/tip/oct-ctl \
         && sudo chmod +x /home/ubuntu/oct-ctl \
         && /home/ubuntu/oct-ctl &
     "#;


### PR DESCRIPTION
### TL;DR

Modified the oct-ctl release workflow to create continuous releases on main branch pushes.

### What changed?

- Changed trigger from `release: [published]` to `push` on `main` branch
- Updated release upload step to create and manage a `tip` tag
- Configured automatic creation of pre-releases labeled "Latest Continuous Release"

### How to test?

1. Push a commit to the main branch
2. Verify that the workflow runs automatically
3. Check that a new pre-release is created with the "Latest Continuous Release" title
4. Confirm the oct-ctl binary is attached to the release
5. Verify the `tip` tag points to the latest main branch commit

### Why make this change?

Enables continuous delivery of oct-ctl binaries by automatically creating pre-releases on main branch updates, making it easier for users to access the latest version without waiting for official releases.

<!-- branch-stack -->

- `main`
  - \#109 :point\_left:
