### PR TITLE
Add git config for release workflow.

### DIFF
--- a/.github/workflows/release-oct-ctl.yml
+++ b/.github/workflows/release-oct-ctl.yml
@@ -13,8 +13,8 @@ env:
 
 # Add this concurrency configuration
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -41,10 +41,19 @@ jobs:
     - name: Build oct-ctl
       run: cargo build -p oct-ctl --release --verbose
 
-    - name: Upload release
-      env:
-        GITHUB_TOKEN: ${{ github.TOKEN }}
+    - name: Tip Tag
       run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git tag -fa tip -m "Latest Continuous Release"
         git push -f origin tip
-        gh release create tip target/release/oct-ctl --title "Latest Continuous Release" --notes "This is the latest build of oct-ctl." --target tip --prerelease --force
+
+    - name: Upload release
+      uses: softprops/action-gh-release@v2
+      with:
+        name: 'oct-ctl Tip'
+        prerelease: true
+        tag_name: tip
+        target_commitish: ${{ github.sha }}
+        files: |
+          target/release/oct-ctl


### PR DESCRIPTION
### TL;DR

Improved the GitHub Actions workflow for oct-ctl releases by implementing more reliable release management and tagging.

### What changed?

- Modified concurrency settings to prevent workflow conflicts
- Added explicit git configuration for the bot user
- Replaced manual release creation with `softprops/action-gh-release`
- Separated tag creation and release steps for better control
- Updated release naming and file handling

### How to test?

1. Push a commit to trigger the workflow
2. Verify that a new "oct-ctl Tip" release is created
3. Confirm the release contains the latest oct-ctl binary
4. Check that the "tip" tag is properly updated

### Why make this change?

The previous release process was prone to race conditions and used deprecated methods. This update provides more reliable releases, better error handling, and clearer separation between tagging and release creation steps.

<!-- branch-stack -->

- `main`
  - \#112 :point\_left:
