### PR TITLE
Add tests for `Resource` impl for `aws::InstanceRole`

### DIFF
--- a/crates/oct-cloud/src/aws.rs
+++ b/crates/oct-cloud/src/aws.rs
@@ -840,4 +840,100 @@ mod tests {
         // Assert
         assert!(destroy_result.is_err());
     }
+
+    #[tokio::test]
+    async fn test_create_instance_iam_role() {
+        // Arrange
+        let mut iam_impl_mock = MockIAMImpl::default();
+        iam_impl_mock
+            .expect_create_instance_iam_role()
+            .with(eq("test".to_string()), eq("".to_string()), eq(vec![]))
+            .return_once(|_, _, _| Ok(()));
+
+        let mut instance_role = InstanceRole {
+            client: iam_impl_mock,
+            name: "test".to_string(),
+            region: "us-west-2".to_string(),
+            assume_role_policy: "".to_string(),
+            policy_arns: vec![],
+        };
+
+        // Act
+        let create_result = instance_role.create().await;
+
+        // Assert
+        assert!(create_result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_create_instance_iam_role_error() {
+        // Arrange
+        let mut iam_impl_mock = MockIAMImpl::default();
+        iam_impl_mock
+            .expect_create_instance_iam_role()
+            .with(eq("test".to_string()), eq("".to_string()), eq(vec![]))
+            .return_once(|_, _, _| Err("Error".into()));
+
+        let mut instance_role = InstanceRole {
+            client: iam_impl_mock,
+            name: "test".to_string(),
+            region: "us-west-2".to_string(),
+            assume_role_policy: "".to_string(),
+            policy_arns: vec![],
+        };
+
+        // Act
+        let create_result = instance_role.create().await;
+
+        // Assert
+        assert!(create_result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_destroy_instance_iam_role() {
+        // Arrange
+        let mut iam_impl_mock = MockIAMImpl::default();
+        iam_impl_mock
+            .expect_delete_instance_iam_role()
+            .with(eq("test".to_string()), eq(vec![]))
+            .return_once(|_, _| Ok(()));
+
+        let mut instance_role = InstanceRole {
+            client: iam_impl_mock,
+            name: "test".to_string(),
+            region: "us-west-2".to_string(),
+            assume_role_policy: "".to_string(),
+            policy_arns: vec![],
+        };
+
+        // Act
+        let destroy_result = instance_role.destroy().await;
+
+        // Assert
+        assert!(destroy_result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_destroy_instance_iam_role_error() {
+        // Arrange
+        let mut iam_impl_mock = MockIAMImpl::default();
+        iam_impl_mock
+            .expect_delete_instance_iam_role()
+            .with(eq("test".to_string()), eq(vec![]))
+            .return_once(|_, _| Err("Error".into()));
+
+        let mut instance_role = InstanceRole {
+            client: iam_impl_mock,
+            name: "test".to_string(),
+            region: "us-west-2".to_string(),
+            assume_role_policy: "".to_string(),
+            policy_arns: vec![],
+        };
+
+        // Act
+        let destroy_result = instance_role.destroy().await;
+
+        // Assert
+        assert!(destroy_result.is_err());
+    }
 }


### PR DESCRIPTION
### TL;DR

Added unit tests for AWS IAM instance role creation and destruction functionality.

### What changed?

Added four new unit tests to validate the behavior of IAM instance role operations:

- `test_create_instance_iam_role`: Tests successful role creation
- `test_create_instance_iam_role_error`: Tests error handling during role creation
- `test_destroy_instance_iam_role`: Tests successful role deletion
- `test_destroy_instance_iam_role_error`: Tests error handling during role deletion

### How to test?

Run the test suite:

```bash
cargo test test_create_instance_iam_role
cargo test test_create_instance_iam_role_error
cargo test test_destroy_instance_iam_role
cargo test test_destroy_instance_iam_role_error
```

### Why make this change?

To ensure reliable and predictable behavior when managing AWS IAM instance roles, improving code quality and maintainability through comprehensive test coverage of both success and error scenarios.

<!-- branch-stack -->

- `main`
  - \#113
    - \#114 :point\_left:
