### PR TITLE
Add `-Dwarnings` to postsubmit `RUSTFLAGS` and fix warnings

### DIFF
--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      RUSTFLAGS: -Cinstrument-coverage
+      RUSTFLAGS: -Dwarnings -Cinstrument-coverage
       LLVM_PROFILE_FILE: 'coverage/%p-%m.profraw'
 
     steps:

--- a/crates/oct-cloud/src/aws.rs
+++ b/crates/oct-cloud/src/aws.rs
@@ -8,16 +8,10 @@ use log;
 #[allow(unused_imports)]
 use mockall::automock;
 
-/// Now we deploy only one EC2 instance where the services from
-/// the config.
-/// In state we store only the information about the instance and
-/// related resources (IAM role, ECR repository, etc.).
-///
-/// User flow:
-/// - Check state of the resource (by resource name from dynamic config)
-/// - Create if not exists
-/// - Update if exists
-
+/// Defines the basic operations for managing cloud resources.
+/// It includes methods for creating and destroying resources asynchronously.
+/// Implementations of this trait should provide the specific logic for
+/// resource management in the context of the cloud provider being used.
 pub trait Resource {
     fn create(
         &mut self,
@@ -33,6 +27,7 @@ struct Ec2Impl {
 }
 
 /// TODO: Add tests using static replay
+#[cfg_attr(test, allow(dead_code))]
 #[cfg_attr(test, automock)]
 impl Ec2Impl {
     fn new(inner: aws_sdk_ec2::Client) -> Self {
@@ -121,6 +116,7 @@ struct IAMImpl {
 }
 
 /// TODO: Add tests using static replay
+#[cfg_attr(test, allow(dead_code))]
 #[cfg_attr(test, automock)]
 impl IAMImpl {
     fn new(inner: aws_sdk_iam::Client) -> Self {

--- a/crates/oct-cloud/src/state.rs
+++ b/crates/oct-cloud/src/state.rs
@@ -1,4 +1,3 @@
-use crate::aws;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -16,8 +15,6 @@ pub struct Ec2InstanceState {
 
 #[cfg(test)]
 mod mocks {
-    use super::*;
-
     pub struct MockEc2Instance {
         pub id: Option<String>,
         pub public_ip: Option<String>,
@@ -89,7 +86,7 @@ mod mocks {
 }
 
 #[cfg(not(test))]
-use aws::{Ec2Instance, InstanceProfile, InstanceRole};
+use crate::aws::{Ec2Instance, InstanceProfile, InstanceRole};
 
 #[cfg(test)]
 use mocks::{

--- a/crates/oct-ctl/src/main.rs
+++ b/crates/oct-ctl/src/main.rs
@@ -26,6 +26,7 @@ struct RemoveContainerPayload {
 #[derive(Clone, Default)]
 struct ContainerEngine;
 
+#[cfg_attr(test, allow(dead_code))]
 impl ContainerEngine {
     /// Runs container using `podman`
     fn run(


### PR DESCRIPTION
- Allows `dead_code` in `test` compilation
- Update `aws::Resource` docstring

Closes #107