### PR TITLE
Implement logic to save multiple services to user state file

### DIFF
--- a/crates/oct-orchestrator/src/user_state.rs
+++ b/crates/oct-orchestrator/src/user_state.rs
@@ -1,18 +1,14 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
-pub(crate) struct UserState {
-    pub service_name: String,
+pub(crate) struct Service {
+    pub name: String,
     pub public_ip: String,
 }
 
-impl UserState {
-    pub(crate) fn new(service_name: String, public_ip: String) -> Self {
-        Self {
-            service_name,
-            public_ip,
-        }
-    }
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub(crate) struct UserState {
+    pub services: Vec<Service>,
 }
 
 #[cfg(test)]
@@ -21,8 +17,22 @@ mod tests {
 
     #[test]
     fn test_user_state() {
-        let user_state = UserState::new("test".to_string(), "127.0.0.1".to_string());
-        assert_eq!(user_state.service_name, "test");
-        assert_eq!(user_state.public_ip, "127.0.0.1");
+        let user_state = UserState {
+            services: vec![
+                Service {
+                    name: "test".to_string(),
+                    public_ip: "test".to_string(),
+                },
+                Service {
+                    name: "test2".to_string(),
+                    public_ip: "test2".to_string(),
+                },
+            ],
+        };
+        assert_eq!(user_state.services.len(), 2);
+        assert_eq!(user_state.services[0].name, "test");
+        assert_eq!(user_state.services[0].public_ip, "test");
+        assert_eq!(user_state.services[1].name, "test2");
+        assert_eq!(user_state.services[1].public_ip, "test2");
     }
 }

--- a/examples/python-fastapi/oct.toml
+++ b/examples/python-fastapi/oct.toml
@@ -8,3 +8,11 @@ internal_port = 8000
 external_port = 8000
 cpus = 250
 memory = 64
+
+[[project.services]]
+name = "app2"
+image = "ghcr.io/opencloudtool/example-python-fastapi:latest"
+internal_port = 8000
+external_port = 8001
+cpus = 250
+memory = 64


### PR DESCRIPTION
### TL;DR
Updated user state file handling to support multiple services and added a second service to the Python FastAPI example.

### What changed?
- Modified the user state file to store an array of services instead of a single service
- Updated the deploy process to append new services to the existing state file
- Enhanced the cleanup process to remove all deployed services
- Added a second FastAPI service to the example configuration with a different external port

### How to test?
1. Navigate to the Python FastAPI example directory
2. Deploy the services using `oct deploy`
3. Verify both services are running:
   - Access the first service on port 8000
   - Access the second service on port 8001
4. Run `oct cleanup` to ensure both services are properly removed

### Why make this change?
The previous implementation only supported deploying a single service. This change enables users to deploy and manage multiple services simultaneously, providing more flexibility for complex applications that require multiple containers.