### PR TITLE
Use `cpus` and `memory` in `oct-ctl`

### DIFF
--- a/crates/oct-orchestrator/src/config.rs
+++ b/crates/oct-orchestrator/src/config.rs
@@ -44,9 +44,9 @@ pub(crate) struct Service {
     /// External port exposed to the public internet
     pub(crate) external_port: u32,
     /// CPU millicores
-    pub(crate) cpu: u32,
+    pub(crate) cpus: u32,
     /// Memory in MB
-    pub(crate) memory: u32,
+    pub(crate) memory: u64,
 }
 
 #[cfg(test)]
@@ -69,16 +69,16 @@ name = "app_1"
 image = "nginx:latest"
 internal_port = 80
 external_port = 80
-cpu = 1024
-memory = 4096
+cpus = 250
+memory = 64
 
 [[project.services]]
 name = "app_2"
 image = "nginx:latest"
 internal_port = 80
 external_port = 80
-cpu = 1024
-memory = 4096
+cpus = 250
+memory = 64
     "#;
 
         let mut file = tempfile::NamedTempFile::new().unwrap();
@@ -99,16 +99,16 @@ memory = 4096
                             image: "nginx:latest".to_string(),
                             internal_port: 80,
                             external_port: 80,
-                            cpu: 1024,
-                            memory: 4096,
+                            cpus: 250,
+                            memory: 64,
                         },
                         Service {
                             name: "app_2".to_string(),
                             image: "nginx:latest".to_string(),
                             internal_port: 80,
                             external_port: 80,
-                            cpu: 1024,
-                            memory: 4096,
+                            cpus: 250,
+                            memory: 64,
                         }
                     ]
                 }

--- a/crates/oct-orchestrator/src/lib.rs
+++ b/crates/oct-orchestrator/src/lib.rs
@@ -64,6 +64,8 @@ impl Orchestrator {
                     service.image.to_string(),
                     service.external_port.to_string(),
                     service.internal_port.to_string(),
+                    service.cpus,
+                    service.memory,
                 )
                 .await;
 

--- a/examples/python-fastapi/oct.toml
+++ b/examples/python-fastapi/oct.toml
@@ -6,5 +6,5 @@ name = "app"
 image = "ghcr.io/opencloudtool/example-python-fastapi:latest"
 internal_port = 8000
 external_port = 8000
-cpu = 250
+cpus = 250
 memory = 64


### PR DESCRIPTION
- Pass these params via HTTP endpoint
- Rename `cpu` to `cpus` in `oct.toml` specs and `python-fastapi` example

Closes #126