### PR TITLE
Update `python-fastapi` example project

### DIFF
--- a/examples/python-fastapi/main.py
+++ b/examples/python-fastapi/main.py
@@ -1,3 +1,5 @@
+import os
+
 from fastapi import FastAPI
 
 app = FastAPI()
@@ -5,4 +7,7 @@ app = FastAPI()
 
 @app.get("/")
 async def root():
-    return {"message": "Hello World"}
+    return {
+        "message": "Hello World",
+        "app_name": os.getenv("APP_NAME"),
+    }

--- a/examples/python-fastapi/oct.toml
+++ b/examples/python-fastapi/oct.toml
@@ -2,18 +2,7 @@
 name = "python-fastapi"
 
 [[project.services]]
-name = "app"
-image = "ghcr.io/opencloudtool/example-python-fastapi:latest"
-internal_port = 8000
-external_port = 8000
-cpus = 250
-memory = 64
-
-[project.services.envs]
-APP_NAME = "app"
-
-[[project.services]]
-name = "app2"
+name = "app_1"
 image = "ghcr.io/opencloudtool/example-python-fastapi:latest"
 internal_port = 8000
 external_port = 8001
@@ -21,4 +10,49 @@ cpus = 250
 memory = 64
 
 [project.services.envs]
-APP_NAME = "app2"
+APP_NAME = "app_1"
+
+[[project.services]]
+name = "app_2"
+image = "ghcr.io/opencloudtool/example-python-fastapi:latest"
+internal_port = 8000
+external_port = 8002
+cpus = 250
+memory = 64
+
+[project.services.envs]
+APP_NAME = "app_2"
+
+# Nginx needs to be started after the applications.
+# It is defined on the bottom because
+# the order matters in the current implementation
+# (services are started one by one in the order they are defined).
+[[project.services]]
+name = "nginx"
+image = "ghcr.io/opencloudtool/nginx-with-conf:latest"
+internal_port = 80
+external_port = 80
+cpus = 250
+memory = 64
+
+[project.services.envs]
+NGINX_CONF = """
+events {
+    worker_connections 1024;
+}
+
+http {
+    upstream app {
+        server app_1:8000;
+        server app_2:8000;
+    }
+
+    server {
+        listen 80;
+
+        location / {
+            proxy_pass http://app;
+        }
+    }
+}
+"""


### PR DESCRIPTION
- 2 app services with Nginx load balancer
- Add app name to the Hello World endpoint response (already deployed as to `ghcr.io/opencloudtool/example-python-fastapi:latest`)

Closes #159 