### PR TITLE
Put dev dependencies into `dev-dependencies` block in crates

### DIFF
--- a/crates/oct-cli/Cargo.toml
+++ b/crates/oct-cli/Cargo.toml
@@ -6,11 +6,13 @@ edition = "2021"
 [dependencies]
 oct-orchestrator = { workspace = true }
 
-assert_cmd = { workspace = true }
 clap = { workspace = true }
 tokio = { workspace = true }
-predicates = { workspace = true }
 env_logger = { workspace = true }
+
+[dev-dependencies]
+assert_cmd = { workspace = true }
+predicates = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/oct-cloud/Cargo.toml
+++ b/crates/oct-cloud/Cargo.toml
@@ -9,9 +9,11 @@ aws-sdk-ec2 = { workspace = true }
 aws-sdk-iam = { workspace = true }
 base64 = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-mockall = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 log = { workspace = true }
+
+[dev-dependencies]
+mockall = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/oct-cloud/src/aws/client.rs
+++ b/crates/oct-cloud/src/aws/client.rs
@@ -1,7 +1,7 @@
 /// AWS service clients implementation
 use aws_sdk_ec2::operation::run_instances::RunInstancesOutput;
 
-#[allow(unused_imports)]
+#[cfg(test)]
 use mockall::automock;
 
 /// AWS EC2 client implementation

--- a/crates/oct-ctl/Cargo.toml
+++ b/crates/oct-ctl/Cargo.toml
@@ -8,12 +8,14 @@ axum = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 log = { workspace = true }
-mockall = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tower-http = { workspace = true, features = ["trace"] }
 tower = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+
+[dev-dependencies]
+mockall = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/oct-ctl/src/main.rs
+++ b/crates/oct-ctl/src/main.rs
@@ -6,9 +6,11 @@ use axum::{
     extract::State, http::StatusCode, response::IntoResponse, routing::get, routing::post, Json,
     Router,
 };
-use mockall::mock;
 use serde::{Deserialize, Serialize};
 use tower_http::trace::{self, TraceLayer};
+
+#[cfg(test)]
+use mockall::mock;
 
 #[derive(Serialize, Deserialize)]
 struct RunContainerPayload {
@@ -165,6 +167,7 @@ impl ContainerEngine {
 // As long as ContainerEngine implemnts Clone, we mock it using
 // mockall::mock macro, more info here:
 // https://docs.rs/mockall/latest/mockall/macro.mock.html#examples
+#[cfg(test)]
 mock! {
     pub ContainerEngine {
         fn run(

--- a/crates/oct-orchestrator/Cargo.toml
+++ b/crates/oct-orchestrator/Cargo.toml
@@ -7,13 +7,15 @@ edition = "2021"
 oct-cloud = { workspace = true }
 
 log = { workspace = true }
-mockito = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tempfile = { workspace = true }
 tokio = { workspace = true }
 toml = { workspace = true }
+
+[dev-dependencies]
+mockito = { workspace = true }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
### TL;DR
Moved test-only dependencies to `dev-dependencies` section in cargo manifests and properly scoped test-related imports with `#[cfg(test)]`.

### What changed?
- Relocated test dependencies (`assert_cmd`, `predicates`, `mockall`, `mockito`, `tempfile`) to `dev-dependencies` in respective crate manifests
- Added `#[cfg(test)]` attributes to test-specific imports and mock implementations
- Removed unnecessary `#[allow(unused_imports)]` attribute from mockall import

### Why make this change?
This change improves the project's dependency management by properly separating production and test dependencies. This results in smaller binary sizes and clearer dependency boundaries, as test-only dependencies won't be compiled into the release builds.

Closes #180