### PR TITLE
Add Subnet creation

### DIFF
--- a/crates/oct-orchestrator/src/lib.rs
+++ b/crates/oct-orchestrator/src/lib.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use oct_cloud::aws::resource::{Ec2Instance, InstanceType, VPC};
+use oct_cloud::aws::resource::{Ec2Instance, InstanceType, Subnet, VPC};
 use oct_cloud::resource::Resource;
 use oct_cloud::state;
 
@@ -35,7 +35,24 @@ impl Orchestrator {
                 user_state::UserState::default()
             };
 
-        let vpc = VPC::new(None, "us-west-2".to_string(), "ct-app-vpc".to_string()).await;
+        // Initialize Subnet
+        let subnet = Subnet::new(
+            None,
+            "us-west-2".to_string(),
+            "10.0.0.0/24".to_string(),
+            None,
+            "ct-app-subnet".to_string(),
+        )
+        .await;
+
+        // Initialize VPC
+        let vpc = VPC::new(
+            None,
+            "us-west-2".to_string(),
+            "ct-app-vpc".to_string(),
+            subnet,
+        )
+        .await;
 
         // Create EC2 instance
         let mut instance = Ec2Instance::new(


### PR DESCRIPTION
### TL;DR
Added subnet creation and management capabilities to AWS VPC infrastructure.

### What changed?
- Implemented subnet creation and deletion functionality in AWS EC2 client
- Added a new Subnet struct to manage subnet resources
- Modified VPC to include and manage a subnet as part of its lifecycle
- Updated state management to handle subnet state persistence
- Added corresponding test coverage for subnet operations

### How to test?
1. Run the test suite to verify subnet creation/deletion functionality
2. Create a new VPC using the orchestrator
3. Verify subnet is automatically created within the VPC
4. Destroy the VPC and confirm subnet is properly cleaned up

### Why make this change?
VPCs require subnets to properly isolate and organize network resources. This change provides the necessary infrastructure to create and manage subnets, which is essential for proper network segmentation and EC2 instance deployment.