### PR TITLE
Update `oct.toml` and user state specs

### DIFF
--- a/crates/oct-orchestrator/src/config.rs
+++ b/crates/oct-orchestrator/src/config.rs
@@ -29,15 +29,14 @@ impl Config {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct Project {
     pub name: String,
-    pub services: Vec<Service>,
+
+    pub services: HashMap<String, Service>,
 }
 
 /// Configuration for a service
 /// This configuration is managed by the user and used to deploy the service
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct Service {
-    /// Name of the service
-    pub(crate) name: String,
     /// Image to use for the container
     pub(crate) image: String,
     /// Internal port exposed from the container
@@ -68,21 +67,19 @@ mod tests {
 [project]
 name = "example"
 
-[[project.services]]
-name = "app_1"
+[project.services.app_1]
 image = "nginx:latest"
 internal_port = 80
 external_port = 80
 cpus = 250
 memory = 64
 
-[project.services.envs]
+[project.services.app_1.envs]
 KEY1 = "VALUE1"
 KEY2 = """Multiline
 string"""
 
-[[project.services]]
-name = "app_2"
+[project.services.app_2]
 image = "nginx:latest"
 cpus = 250
 memory = 64
@@ -100,29 +97,33 @@ memory = 64
             Config {
                 project: Project {
                     name: "example".to_string(),
-                    services: vec![
-                        Service {
-                            name: "app_1".to_string(),
-                            image: "nginx:latest".to_string(),
-                            internal_port: Some(80),
-                            external_port: Some(80),
-                            cpus: 250,
-                            memory: 64,
-                            envs: HashMap::from([
-                                ("KEY1".to_string(), "VALUE1".to_string()),
-                                ("KEY2".to_string(), "Multiline\nstring".to_string()),
-                            ]),
-                        },
-                        Service {
-                            name: "app_2".to_string(),
-                            image: "nginx:latest".to_string(),
-                            internal_port: None,
-                            external_port: None,
-                            cpus: 250,
-                            memory: 64,
-                            envs: HashMap::new(),
-                        }
-                    ]
+                    services: HashMap::from([
+                        (
+                            "app_1".to_string(),
+                            Service {
+                                image: "nginx:latest".to_string(),
+                                internal_port: Some(80),
+                                external_port: Some(80),
+                                cpus: 250,
+                                memory: 64,
+                                envs: HashMap::from([
+                                    ("KEY1".to_string(), "VALUE1".to_string()),
+                                    ("KEY2".to_string(), "Multiline\nstring".to_string()),
+                                ]),
+                            }
+                        ),
+                        (
+                            "app_2".to_string(),
+                            Service {
+                                image: "nginx:latest".to_string(),
+                                internal_port: None,
+                                external_port: None,
+                                cpus: 250,
+                                memory: 64,
+                                envs: HashMap::new(),
+                            }
+                        ),
+                    ])
                 }
             }
         );

--- a/crates/oct-orchestrator/src/user_state.rs
+++ b/crates/oct-orchestrator/src/user_state.rs
@@ -1,14 +1,15 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct Service {
-    pub name: String,
     pub public_ip: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub(crate) struct UserState {
-    pub services: Vec<Service>,
+    pub services: HashMap<String, Service>,
 }
 
 #[cfg(test)]
@@ -18,21 +19,23 @@ mod tests {
     #[test]
     fn test_user_state() {
         let user_state = UserState {
-            services: vec![
-                Service {
-                    name: "test".to_string(),
-                    public_ip: "test".to_string(),
-                },
-                Service {
-                    name: "test2".to_string(),
-                    public_ip: "test2".to_string(),
-                },
-            ],
+            services: HashMap::from([
+                (
+                    "test".to_string(),
+                    Service {
+                        public_ip: "test".to_string(),
+                    },
+                ),
+                (
+                    "test2".to_string(),
+                    Service {
+                        public_ip: "test2".to_string(),
+                    },
+                ),
+            ]),
         };
         assert_eq!(user_state.services.len(), 2);
-        assert_eq!(user_state.services[0].name, "test");
-        assert_eq!(user_state.services[0].public_ip, "test");
-        assert_eq!(user_state.services[1].name, "test2");
-        assert_eq!(user_state.services[1].public_ip, "test2");
+        assert_eq!(user_state.services["test"].public_ip, "test");
+        assert_eq!(user_state.services["test2"].public_ip, "test2");
     }
 }

--- a/examples/python-fastapi/oct.toml
+++ b/examples/python-fastapi/oct.toml
@@ -1,37 +1,34 @@
 [project]
 name = "python-fastapi"
 
-[[project.services]]
-name = "app_1"
+[project.services.app_1]
 image = "ghcr.io/opencloudtool/example-python-fastapi:latest"
 cpus = 250
 memory = 64
 
-[project.services.envs]
+[project.services.app_1.envs]
 APP_NAME = "app_1"
 
-[[project.services]]
-name = "app_2"
+[project.services.app_2]
 image = "ghcr.io/opencloudtool/example-python-fastapi:latest"
 cpus = 250
 memory = 64
 
-[project.services.envs]
+[project.services.app_2.envs]
 APP_NAME = "app_2"
 
 # Nginx needs to be started after the applications.
 # It is defined on the bottom because
 # the order matters in the current implementation
 # (services are started one by one in the order they are defined).
-[[project.services]]
-name = "nginx"
+[project.services.nginx]
 image = "ghcr.io/opencloudtool/nginx-with-conf:latest"
 internal_port = 80
 external_port = 80
 cpus = 250
 memory = 64
 
-[project.services.envs]
+[project.services.nginx.envs]
 NGINX_CONF = """
 events {
     worker_connections 1024;


### PR DESCRIPTION
### TL;DR

Restructured service configuration from array-based to map-based representation, removing redundant name field from Service struct.

### What changed?

- Changed `services` field in Project struct from `Vec<Service>` to `HashMap<String, Service>`
- Removed redundant `name` field from Service struct as it's now the key in the HashMap
- Updated TOML configuration format to use table syntax instead of array syntax
- Modified service iteration logic in the orchestrator to use key-value pairs
- Updated user state to use HashMap for services instead of Vec
- Adjusted example configuration files to match new format

### Why make this change?

Using a HashMap provides better organization and direct access to services by name, eliminating the need to store the name twice. This change also makes the configuration more intuitive and reduces the possibility of name mismatches between the service definition and its reference.

Closes #188 