### PR TITLE
Preliminary work to add support of multiple instances

### DIFF
--- a/crates/oct-orchestrator/src/lib.rs
+++ b/crates/oct-orchestrator/src/lib.rs
@@ -34,18 +34,30 @@ impl Orchestrator {
         let (services_to_create, services_to_remove) =
             Self::get_user_services_to_create_and_delete(&config, &user_state);
 
-        log::info!("Services to create: {services_to_create:?}");
-        log::info!("Services to remove: {services_to_remove:?}");
+        log::info!("Services to create: {services_to_create:?}"); // Give more capacity
+        log::info!("Services to remove: {services_to_remove:?}"); // Reduce capacity
 
-        let public_ip = self.prepare_infrastructure().await?; // TODO(#189): pass info about required resources
+        let instances = self.prepare_infrastructure().await?; // TODO(#189): pass info about required resources
 
-        let oct_ctl_client = oct_ctl_sdk::Client::new(public_ip.clone(), None);
+        for instance in &instances {
+            let Some(public_ip) = instance.public_ip.clone() else {
+                log::error!("Instance {:?} has no public IP", instance.id);
 
-        self.check_host_health(&oct_ctl_client).await?;
+                continue;
+            };
 
+            let oct_ctl_client = oct_ctl_sdk::Client::new(public_ip.clone());
+
+            let host_health = self.check_host_health(&oct_ctl_client).await;
+            if host_health.is_err() {
+                log::error!("Failed to check '{}' host health", public_ip);
+            }
+        }
+
+        // All instances are healthy and ready to serve user services
         self.deploy_user_services(
             &config,
-            &oct_ctl_client,
+            &instances,
             &services_to_create,
             &services_to_remove,
         )
@@ -73,7 +85,7 @@ impl Orchestrator {
                 // Remove container from instance
                 log::info!("Removing container for service: {}", name);
 
-                let oct_ctl_client = oct_ctl_sdk::Client::new(service.public_ip, None);
+                let oct_ctl_client = oct_ctl_sdk::Client::new(service.public_ip);
 
                 let response = oct_ctl_client.remove_container(name.clone()).await;
 
@@ -122,7 +134,7 @@ impl Orchestrator {
     }
 
     /// Prepares L1 infrastructure (VM instances and base networking)
-    async fn prepare_infrastructure(&self) -> Result<String, Box<dyn std::error::Error>> {
+    async fn prepare_infrastructure(&self) -> Result<Vec<Ec2Instance>, Box<dyn std::error::Error>> {
         // Trying to get existing state to return public IP
         // The logic will be updated when we support multiple instances
         if std::path::Path::new(&self.state_file_path).exists() {
@@ -131,7 +143,7 @@ impl Orchestrator {
 
             log::info!("Instance already exists: {}", instance_state.id);
 
-            return Ok(instance_state.public_ip);
+            return Ok(vec![instance_state.new_from_state().await?]);
         }
 
         let subnet = Subnet::new(
@@ -167,7 +179,6 @@ impl Orchestrator {
         instance.create().await?;
 
         let instance_id = instance.id.clone().ok_or("No instance id")?;
-        let public_ip = instance.public_ip.clone().ok_or("Public IP not found")?;
 
         log::info!("Instance created: {instance_id}");
 
@@ -176,7 +187,7 @@ impl Orchestrator {
         let json_data = serde_json::to_string_pretty(&instance_state)?;
         fs::write(&self.state_file_path, json_data)?;
 
-        Ok(public_ip)
+        Ok(vec![instance])
     }
 
     /// Waits for a host to be healthy
@@ -241,10 +252,14 @@ impl Orchestrator {
     async fn deploy_user_services(
         &self,
         config: &config::Config,
-        oct_ctl_client: &oct_ctl_sdk::Client,
+        instances: &[Ec2Instance],
         services_to_create: &[String],
         services_to_remove: &[String],
     ) -> Result<(), Box<dyn std::error::Error>> {
+        let instance = instances.first().ok_or("No instances available")?;
+        let oct_ctl_client =
+            oct_ctl_sdk::Client::new(instance.public_ip.as_ref().ok_or("No public IP")?.clone());
+
         for service_name in services_to_remove {
             log::info!("Stopping container for service: {}", service_name);
 

--- a/crates/oct-orchestrator/src/oct_ctl_sdk.rs
+++ b/crates/oct-orchestrator/src/oct_ctl_sdk.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 /// HTTP client to access `oct-ctl`'s API
 pub(crate) struct Client {
+    // TODO: Use reference instead
     pub(crate) public_ip: String,
     port: u16,
 }
@@ -28,10 +29,10 @@ struct RemoveContainerRequest {
 impl Client {
     const DEFAULT_PORT: u16 = 31888;
 
-    pub(crate) fn new(public_ip: String, port: Option<u16>) -> Self {
+    pub(crate) fn new(public_ip: String) -> Self {
         Self {
             public_ip,
-            port: port.unwrap_or(Self::DEFAULT_PORT),
+            port: Self::DEFAULT_PORT,
         }
     }
 
@@ -146,7 +147,10 @@ mod tests {
             .match_header("Accept", "application/json")
             .create();
 
-        let client = Client::new(ip, Some(port));
+        let client = Client {
+            public_ip: ip,
+            port,
+        };
 
         // Act
         let response = client
@@ -178,7 +182,10 @@ mod tests {
             .match_header("Accept", "application/json")
             .create();
 
-        let client = Client::new(ip, Some(port));
+        let client = Client {
+            public_ip: ip,
+            port,
+        };
 
         // Act
         let response = client
@@ -210,7 +217,10 @@ mod tests {
             .match_header("Accept", "application/json")
             .create();
 
-        let client = Client::new(ip, Some(port));
+        let client = Client {
+            public_ip: ip,
+            port,
+        };
 
         // Act
         let response = client.remove_container("test".to_string()).await;
@@ -232,7 +242,10 @@ mod tests {
             .match_header("Accept", "application/json")
             .create();
 
-        let client = Client::new(ip, Some(port));
+        let client = Client {
+            public_ip: ip,
+            port,
+        };
 
         // Act
         let response = client.remove_container("test".to_string()).await;


### PR DESCRIPTION
- Use list of instances instead of one instance in `Orchestrator::deploy`
- Remove `port` arg from `oct_ctl_sdk::Client::new`, use only default

Related to #189