### PR TITLE
Add destroy function for ECR Resource and client

### DIFF
--- a/crates/oct-cloud/src/aws/client.rs
+++ b/crates/oct-cloud/src/aws/client.rs
@@ -683,6 +683,22 @@ impl ECRImpl {
 
         Ok(registry_id)
     }
+
+    pub(super) async fn delete_repository(
+        &self,
+        name: String,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        log::info!("Deleting ECR repository");
+        self.inner
+            .delete_repository()
+            .repository_name(name)
+            .send()
+            .await?;
+
+        log::info!("Deleted ECR repository");
+
+        Ok(())
+    }
 }
 
 // TODO: Is there a better way to expose mocked structs?


### PR DESCRIPTION
Add destroy function to ECR Resource and aws client

Related to #176 