### PR TITLE
Add pre-commit config file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+-   repo: local
+    hooks:
+    -   id: rust-linting
+        name: Rust linting
+        description: Run cargo fmt on files included in the commit. rustfmt should be installed before-hand.
+        entry: cargo fmt --all --
+        pass_filenames: true
+        types: [file, rust]
+        language: system
+    -   id: rust-clippy
+        name: Rust clippy
+        description: Run cargo clippy on files included in the commit. clippy should be installed before-hand.
+        entry: cargo clippy --all --
+        pass_filenames: false
+        types: [file, rust]
+        language: system

--- a/README.md
+++ b/README.md
@@ -17,7 +17,13 @@ Each version of OpenCloudTool has a mini-project to prove the design and impleme
 
 ![v0.3.0](./docs/v0.3.0.excalidraw.png)
 
-## Usage
+## Development
+
+### Install pre-commit hooks
+
+```bash
+pre-commit install
+```
 
 ### Build project
 


### PR DESCRIPTION
### TL;DR
Added pre-commit hooks for Rust code formatting and linting

### What changed?
- Added `.pre-commit-config.yaml` configuration file
- Configured two local pre-commit hooks:
  1. `rust-linting`: Runs `cargo fmt` to format Rust files
  2. `rust-clippy`: Runs `cargo clippy` to perform static analysis

### How to test?
1. Install pre-commit: `pip install pre-commit`
2. Install the hooks: `pre-commit install`
3. Make changes to any Rust file
4. Attempt to commit the changes
5. Verify that formatting and linting checks run automatically
