### PR TITLE
Add tests for `container`, `executor` mods in `oct-ctl`

### DIFF
--- a/crates/oct-ctl/src/container.rs
+++ b/crates/oct-ctl/src/container.rs
@@ -1,6 +1,11 @@
 use std::collections::HashMap;
 use std::process::Command;
 
+#[cfg(test)]
+use crate::executor::mocks::MockCommandExecutor as CommandExecutor;
+#[cfg(not(test))]
+use crate::executor::CommandExecutor;
+
 /// Container manager options
 #[derive(Clone, Default)]
 enum ContainerManager {
@@ -20,6 +25,7 @@ impl ContainerManager {
 #[derive(Clone, Default)]
 pub(crate) struct ContainerEngine {
     manager: ContainerManager,
+    executor: CommandExecutor,
 }
 
 #[cfg_attr(test, allow(dead_code))]
@@ -37,15 +43,20 @@ impl ContainerEngine {
         memory: u64,
         envs: &HashMap<String, String>,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let network_create_cmd = Command::new(self.manager.as_str())
-            .args(["network", "create", Self::NETWORK_NAME])
-            .output()?;
+        // We accept errors here, as network might already exist
+        let network_create_output =
+            self.executor
+                .execute(Command::new(self.manager.as_str()).args([
+                    "network",
+                    "create",
+                    Self::NETWORK_NAME,
+                ]))?;
 
         log::info!(
             "Network create command output: status={:?}, stdout={:?}, stderr={:?}",
-            network_create_cmd.status,
-            network_create_cmd.stdout,
-            network_create_cmd.stderr
+            network_create_output.status,
+            network_create_output.stdout,
+            network_create_output.stderr
         );
 
         let run_container_args = Self::build_run_container_args(
@@ -58,9 +69,9 @@ impl ContainerEngine {
             envs,
         );
 
-        let run_container_cmd = Command::new(self.manager.as_str())
-            .args(&run_container_args)
-            .output()?;
+        let run_container_cmd = self
+            .executor
+            .execute(Command::new(self.manager.as_str()).args(&run_container_args))?;
 
         log::info!(
             "Run container command output: status={:?}, stdout={:?}, stderr={:?}",
@@ -69,18 +80,23 @@ impl ContainerEngine {
             run_container_cmd.stderr
         );
 
-        Ok(())
+        if run_container_cmd.status.success() {
+            Ok(())
+        } else {
+            Err("Failed to run container".into())
+        }
     }
 
     /// Removes container
     pub(crate) fn remove(&self, name: &str) -> Result<(), Box<dyn std::error::Error>> {
-        let command = Command::new(self.manager.as_str())
-            .args(["rm", "-f", name])
-            .output();
+        let output = self
+            .executor
+            .execute(Command::new(self.manager.as_str()).args(["rm", "-f", name]))?;
 
-        match command {
-            Ok(_) => Ok(()),
-            Err(err) => Err(Box::new(err)),
+        if output.status.success() {
+            Ok(())
+        } else {
+            Err("Failed to remove container".into())
         }
     }
 
@@ -159,5 +175,117 @@ pub(crate) mod mocks {
         impl Clone for ContainerEngine {
             fn clone(&self) -> Self;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::process::ExitStatusExt;
+    use std::process::{ExitStatus, Output};
+
+    use super::*;
+
+    fn get_command_executor_mock(exit_code: i32) -> CommandExecutor {
+        let mut mock_command_executor = CommandExecutor::default();
+        mock_command_executor.expect_execute().returning(move |_| {
+            Ok(Output {
+                status: ExitStatus::from_raw(exit_code),
+                stdout: Vec::new(),
+                stderr: Vec::new(),
+            })
+        });
+
+        mock_command_executor
+    }
+
+    #[test]
+    fn test_container_engine_run_success() {
+        // Arrange
+        let mock_command_executor = get_command_executor_mock(0);
+
+        let container_engine = ContainerEngine {
+            manager: ContainerManager::Podman,
+            executor: mock_command_executor,
+        };
+
+        // Act
+        let run_result = container_engine.run(
+            "test",
+            "ubuntu:latest",
+            Some(80),
+            Some(8080),
+            1,
+            512,
+            &HashMap::from([("KEY".to_string(), "VALUE".to_string())]),
+        );
+
+        // Assert
+        assert!(run_result.is_ok());
+    }
+
+    #[test]
+    fn test_container_engine_run_failure() {
+        // Arrange
+        let mock_command_executor = get_command_executor_mock(1);
+
+        let container_engine = ContainerEngine {
+            manager: ContainerManager::Podman,
+            executor: mock_command_executor,
+        };
+
+        // Act
+        let run_result = container_engine.run(
+            "test",
+            "ubuntu:latest",
+            Some(80),
+            Some(8080),
+            1,
+            512,
+            &HashMap::new(),
+        );
+
+        // Assert
+        assert!(run_result.is_err());
+    }
+
+    #[test]
+    fn test_container_engine_remove_success() {
+        // Arrange
+        let mock_command_executor = get_command_executor_mock(0);
+
+        let container_engine = ContainerEngine {
+            manager: ContainerManager::Podman,
+            executor: mock_command_executor,
+        };
+
+        // Act
+        let remove_result = container_engine.remove("test");
+
+        // Assert
+        assert!(remove_result.is_ok());
+    }
+
+    #[test]
+    fn test_container_engine_remove_failure() {
+        // Arrange
+        let mock_command_executor = get_command_executor_mock(1);
+
+        let container_engine = ContainerEngine {
+            manager: ContainerManager::Podman,
+            executor: mock_command_executor,
+        };
+
+        // Act
+        let remove_result = container_engine.remove("test");
+
+        // Assert
+        assert!(remove_result.is_err());
+    }
+
+    #[test]
+    fn test_container_manager_as_str() {
+        let container_manager = ContainerManager::Podman;
+
+        assert_eq!(container_manager.as_str(), "podman");
     }
 }

--- a/crates/oct-ctl/src/executor.rs
+++ b/crates/oct-ctl/src/executor.rs
@@ -1,0 +1,55 @@
+use std::process::{Command, Output};
+
+/// CLI command executor
+#[derive(Clone, Default)]
+pub(crate) struct CommandExecutor;
+
+impl CommandExecutor {
+    #[allow(clippy::unused_self)]
+    pub(crate) fn execute(&self, command: &mut Command) -> Result<Output, std::io::Error> {
+        command.output()
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod mocks {
+    use super::*;
+
+    use mockall::mock;
+
+    mock! {
+        pub(crate) CommandExecutor {
+            pub(crate) fn execute(&self, command: &mut Command) -> Result<Output, std::io::Error>;
+        }
+
+        impl Clone for CommandExecutor {
+            fn clone(&self) -> Self;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_command_executor_execute() {
+        // Arrange
+        let command_executor = CommandExecutor;
+
+        let mut command = Command::new("echo");
+        command.args(["hello"]);
+
+        // Act
+        let output = command_executor.execute(&mut command);
+
+        // Assert
+        assert!(output.is_ok());
+
+        let unwrapped_output = output.unwrap();
+
+        assert_eq!(unwrapped_output.status.success(), true);
+        assert_eq!(unwrapped_output.stdout, b"hello\n");
+        assert_eq!(unwrapped_output.stderr, b"");
+    }
+}

--- a/crates/oct-ctl/src/main.rs
+++ b/crates/oct-ctl/src/main.rs
@@ -1,4 +1,5 @@
 mod container;
+mod executor;
 mod service;
 
 #[tokio::main]


### PR DESCRIPTION
- Extract `executor.rs` mod that executes CLI commands
- Ignore `clippy::unused_self` warning in `CommandExecutor::execute`

Closes #250