### PR TITLE
Integrate S3 state backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A tool to hide the complexity of the cloud.
 
 - [Multiple REST services on the same host with NGINX load balancer](./examples/projects/single-host-rest-service-with-lb/)
 - [Multiple REST services on different hosts with NGINX load balancer](./examples/projects/multi-host-rest-service-with-lb/)
+- [S3 remote state storage](./examples/projects/s3-remote-state-storage/)
 
 ## High Level Design
 

--- a/crates/oct-cli/src/main.rs
+++ b/crates/oct-cli/src/main.rs
@@ -6,10 +6,6 @@ struct Cli {
     #[clap(subcommand)]
     command: Commands,
 
-    /// Path to the infra state file
-    #[clap(long, default_value = "./state.json")]
-    state_file_path: String,
-
     /// Path to the user state file
     #[clap(long, default_value = "./user_state.json")]
     user_state_file_path: String,
@@ -37,8 +33,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let cli = Cli::parse();
 
-    let orchestrator =
-        oct_orchestrator::Orchestrator::new(cli.state_file_path, cli.user_state_file_path);
+    let orchestrator = oct_orchestrator::Orchestrator::new(cli.user_state_file_path);
 
     match &cli.command {
         Commands::Deploy => orchestrator.deploy().await?,
@@ -61,7 +56,6 @@ mod tests {
         let cli = Cli::parse_from(["app", "deploy"]);
 
         // Assert
-        assert_eq!(cli.state_file_path, "./state.json");
         assert_eq!(cli.user_state_file_path, "./user_state.json");
         assert_eq!(cli.dockerfile_path, ".");
         assert_eq!(cli.context_path, ".");

--- a/examples/projects/s3-remote-state-storage/oct.toml
+++ b/examples/projects/s3-remote-state-storage/oct.toml
@@ -1,0 +1,12 @@
+[project]
+name = "s3-remote-state-storage"
+
+[project.state_backend.s3]
+region = "us-west-2"
+bucket = "oct-state"
+key = "state.json"
+
+[project.services.app_1]
+image = "ghcr.io/opencloudtool/example-python-fastapi:latest"
+cpus = 250
+memory = 64


### PR DESCRIPTION
- Use state backend removal in `Orchestrator::destroy`
- Remove `state_file_path` from CLI and Orchestrator
- Add project example

Closes #227