### PR TITLE
Add support of custom `command` in containers

### DIFF
--- a/crates/oct-ctl/src/container.rs
+++ b/crates/oct-ctl/src/container.rs
@@ -35,8 +35,9 @@ impl ContainerEngine {
     /// Runs container using `podman`
     pub(crate) fn run(
         &self,
-        name: &str,
-        image: &str,
+        name: String,
+        image: String,
+        command: Option<String>,
         external_port: Option<u32>,
         internal_port: Option<u32>,
         cpus: u32,
@@ -57,6 +58,7 @@ impl ContainerEngine {
         let run_container_args = Self::build_run_container_args(
             name,
             image,
+            command,
             external_port,
             internal_port,
             cpus,
@@ -91,8 +93,9 @@ impl ContainerEngine {
     }
 
     fn build_run_container_args(
-        name: &str,
-        image: &str,
+        name: String,
+        image: String,
+        command: Option<String>,
         external_port: Option<u32>,
         internal_port: Option<u32>,
         cpus: u32,
@@ -109,7 +112,7 @@ impl ContainerEngine {
             "always".to_string(),
             "-d".to_string(),
             "--name".to_string(),
-            name.to_string(),
+            name,
             "--cpus".to_string(),
             cpus_str,
             "--memory".to_string(),
@@ -131,7 +134,11 @@ impl ContainerEngine {
             run_container_args.push(env_str);
         }
 
-        run_container_args.push(image.to_string());
+        run_container_args.push(image);
+
+        if let Some(command) = command {
+            run_container_args.push(command);
+        }
 
         run_container_args
     }
@@ -150,8 +157,9 @@ pub(crate) mod mocks {
         pub(crate) ContainerEngine {
             pub(crate) fn run(
                 &self,
-                name: &str,
-                image: &str,
+                name: String,
+                image: String,
+                command: Option<String>,
                 external_port: Option<u32>,
                 internal_port: Option<u32>,
                 cpus: u32,
@@ -200,8 +208,9 @@ mod tests {
 
         // Act
         let run_result = container_engine.run(
-            "test",
-            "ubuntu:latest",
+            "test".to_string(),
+            "ubuntu:latest".to_string(),
+            Some("echo hello".to_string()),
             Some(80),
             Some(8080),
             1,
@@ -225,8 +234,9 @@ mod tests {
 
         // Act
         let run_result = container_engine.run(
-            "test",
-            "ubuntu:latest",
+            "test".to_string(),
+            "ubuntu:latest".to_string(),
+            Some("echo hello".to_string()),
             Some(80),
             Some(8080),
             1,

--- a/crates/oct-orchestrator/src/config.rs
+++ b/crates/oct-orchestrator/src/config.rs
@@ -64,6 +64,8 @@ pub(crate) struct Service {
     pub(crate) image: String,
     /// Path to the Dockerfile
     pub(crate) dockerfile_path: Option<String>,
+    /// Command to run in the container
+    pub(crate) command: Option<String>,
     /// Internal port exposed from the container
     pub(crate) internal_port: Option<u32>,
     /// External port exposed to the public internet
@@ -131,6 +133,7 @@ path = "./state.json"
 [project.services.app_1]
 image = ""
 dockerfile_path = "Dockerfile"
+command = "echo Hello World!"
 internal_port = 80
 external_port = 80
 cpus = 250
@@ -169,6 +172,7 @@ depends_on = ["app_1"]
                             Service {
                                 image: "".to_string(),
                                 dockerfile_path: Some("Dockerfile".to_string()),
+                                command: Some("echo Hello World!".to_string()),
                                 internal_port: Some(80),
                                 external_port: Some(80),
                                 cpus: 250,
@@ -185,6 +189,7 @@ depends_on = ["app_1"]
                             Service {
                                 image: "nginx:latest".to_string(),
                                 dockerfile_path: None,
+                                command: None,
                                 internal_port: None,
                                 external_port: None,
                                 cpus: 250,
@@ -205,6 +210,7 @@ depends_on = ["app_1"]
         let service = Service {
             image: "nginx:latest".to_string(),
             dockerfile_path: None,
+            command: None,
             internal_port: None,
             external_port: None,
             cpus: 250,
@@ -239,6 +245,7 @@ depends_on = ["app_1"]
         let service = Service {
             image: "nginx:latest".to_string(),
             dockerfile_path: None,
+            command: None,
             internal_port: None,
             external_port: None,
             cpus: 250,

--- a/crates/oct-orchestrator/src/oct_ctl_sdk.rs
+++ b/crates/oct-orchestrator/src/oct_ctl_sdk.rs
@@ -14,6 +14,7 @@ pub(crate) struct Client {
 struct RunContainerRequest {
     name: String,
     image: String,
+    command: Option<String>,
     external_port: Option<u32>,
     internal_port: Option<u32>,
     cpus: u32,
@@ -40,6 +41,7 @@ impl Client {
         &self,
         name: String,
         image: String,
+        command: Option<String>,
         external_port: Option<u32>,
         internal_port: Option<u32>,
         cpus: u32,
@@ -51,6 +53,7 @@ impl Client {
         let request = RunContainerRequest {
             name,
             image,
+            command,
             external_port,
             internal_port,
             cpus,
@@ -153,6 +156,7 @@ mod tests {
             .run_container(
                 "test".to_string(),
                 "nginx:latest".to_string(),
+                Some("echo hello".to_string()),
                 Some(8080),
                 Some(80),
                 250,
@@ -188,6 +192,7 @@ mod tests {
             .run_container(
                 "test".to_string(),
                 "nginx:latest".to_string(),
+                None,
                 Some(8080),
                 Some(80),
                 250,

--- a/crates/oct-orchestrator/src/scheduler.rs
+++ b/crates/oct-orchestrator/src/scheduler.rs
@@ -37,7 +37,8 @@ impl<'a> Scheduler<'a> {
             let response = oct_ctl_client
                 .run_container(
                     service_name.to_string(),
-                    service.image.to_string(),
+                    service.image.clone(),
+                    service.command.clone(),
                     service.external_port,
                     service.internal_port,
                     service.cpus,


### PR DESCRIPTION
- Add optional `command` to `oct.toml` specs and `oct-ctl` REST service and SDK
- Change type of `name` and `image` in `oct-ctl` from `&str` to `String` to make the API more consistent

Closes #224