### PR TITLE
Render system env variables in `oct.toml`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3054,8 +3054,7 @@ dependencies = [
 [[package]]
 name = "tera"
 version = "1.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9d851b45e865f178319da0abdbfe6acbc4328759ff18dafc3a41c16b4cd2ee"
+source = "git+https://github.com/minev-dev/tera.git?rev=1e36d2f8ba66833ce9ad2b46044e21f8240b5299#1e36d2f8ba66833ce9ad2b46044e21f8240b5299"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serde = "1.0.218"
 serde_derive = "1.0.213"
 serde_json = "1.0.140"
 tempfile = "3.18.0"
-tera = "1.20.0"
+tera = { git = "https://github.com/minev-dev/tera.git", rev = "1e36d2f8ba66833ce9ad2b46044e21f8240b5299" } # Contains custom logic to render variables ignoring unknown variables
 tokio = { version = "1.43.0", features = ["full"] }
 mockall = "0.13.1"
 mockito = "1.7.0"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A tool to hide the complexity of the cloud.
 - [S3 remote state storage](./examples/projects/s3-remote-state-storage/)
 - [REST service with domain](./examples/projects/rest-service-with-domain/)
 - [Ray single worker](./examples/projects/ray-single-worker/)
+- [Inject system env variables](./examples/projects/inject-system-env-var/)
 
 ## High Level Design
 

--- a/examples/projects/inject-system-env-var/README.md
+++ b/examples/projects/inject-system-env-var/README.md
@@ -1,0 +1,11 @@
+# Inject system env variables
+
+This example shows how to inject system env (`env`) and
+runtime (`services`) variables into the `oct.toml` file.
+
+## Deploy
+
+```bash
+export IMAGE_TAG=latest
+cargo run -p oct-cli deploy
+```

--- a/examples/projects/inject-system-env-var/oct.toml
+++ b/examples/projects/inject-system-env-var/oct.toml
@@ -1,0 +1,21 @@
+[project]
+name = "inject-system-env-var"
+
+[project.state_backend.local]
+path = "./state.json"
+
+[project.services.app_1]
+image = "ghcr.io/opencloudtool/example-python-fastapi:{{ env.IMAGE_TAG }}"
+cpus = 250
+memory = 64
+
+[project.services.app_2]
+image = "ghcr.io/opencloudtool/example-python-fastapi:{{ env.IMAGE_TAG }}"
+cpus = 250
+memory = 64
+internal_port = 8000
+external_port = 80
+depends_on = ["app_1"]
+
+[project.services.app_2.envs]
+APP_NAME = "app_1 public ip is {{ services.app_1.public_ip }}"


### PR DESCRIPTION
- Use custom version of `tera` that ignores unexisting variables in passed context
- Add project example with system env and runtime variables injection

Closes https://github.com/opencloudtool/opencloudtool/issues/226