### PR TITLE
Move `backend` module from `oct-cloud` to `oct-orchestrator` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2078,7 +2078,6 @@ dependencies = [
 name = "oct-cloud"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "aws-config",
  "aws-sdk-ec2",
  "aws-sdk-ecr",
@@ -2089,7 +2088,6 @@ dependencies = [
  "log",
  "mockall",
  "serde",
- "serde_json",
  "tempfile",
  "tokio",
  "uuid",
@@ -2115,6 +2113,7 @@ dependencies = [
 name = "oct-orchestrator"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "log",
  "mockito",
  "oct-cloud",

--- a/crates/oct-cloud/Cargo.toml
+++ b/crates/oct-cloud/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-async-trait = { workspace = true }
 aws-config = { workspace = true }
 aws-sdk-ec2 = { workspace = true }
 aws-sdk-iam = { workspace = true }
@@ -14,7 +13,6 @@ aws-sdk-s3 = { workspace = true }
 base64 = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
 log = { workspace = true }
 uuid = { workspace = true }
 

--- a/crates/oct-cloud/src/lib.rs
+++ b/crates/oct-cloud/src/lib.rs
@@ -1,4 +1,3 @@
-pub mod backend;
 pub mod resource;
 pub mod state;
 

--- a/crates/oct-orchestrator/Cargo.toml
+++ b/crates/oct-orchestrator/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 oct-cloud = { workspace = true }
 
+async-trait = { workspace = true }
 log = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }

--- a/crates/oct-orchestrator/src/backend.rs
+++ b/crates/oct-orchestrator/src/backend.rs
@@ -1,11 +1,11 @@
 use std::fs;
 
-use crate::aws::resource::S3Bucket;
-use crate::resource::Resource;
-use crate::state;
+use oct_cloud::aws::resource::S3Bucket;
+use oct_cloud::resource::Resource;
+use oct_cloud::state;
 
 #[async_trait::async_trait]
-pub trait StateBackend {
+pub(crate) trait StateBackend {
     /// Saves state to a backend
     async fn save(&self, state: &state::State) -> Result<(), Box<dyn std::error::Error>>;
 
@@ -17,12 +17,12 @@ pub trait StateBackend {
     async fn remove(&self) -> Result<(), Box<dyn std::error::Error>>;
 }
 
-pub struct LocalStateBackend {
+pub(crate) struct LocalStateBackend {
     file_path: String,
 }
 
 impl LocalStateBackend {
-    pub fn new(file_path: &str) -> Self {
+    pub(crate) fn new(file_path: &str) -> Self {
         LocalStateBackend {
             file_path: file_path.to_string(),
         }
@@ -54,14 +54,14 @@ impl StateBackend for LocalStateBackend {
 }
 
 #[allow(dead_code)]
-pub struct S3StateBackend {
+pub(crate) struct S3StateBackend {
     region: String,
     bucket: String,
     key: String,
 }
 
 impl S3StateBackend {
-    pub fn new(region: &str, bucket: &str, key: &str) -> Self {
+    pub(crate) fn new(region: &str, bucket: &str, key: &str) -> Self {
         S3StateBackend {
             region: region.to_string(),
             bucket: bucket.to_string(),
@@ -114,7 +114,7 @@ mod tests {
 
     use std::io::Write;
 
-    use crate::aws::types::RecordType;
+    use oct_cloud::aws::types::RecordType;
 
     #[tokio::test]
     async fn test_state_new_exists() {

--- a/crates/oct-orchestrator/src/lib.rs
+++ b/crates/oct-orchestrator/src/lib.rs
@@ -3,15 +3,16 @@ use std::fs;
 use std::path::Path;
 use std::process::Command;
 
+use backend::{LocalStateBackend, S3StateBackend, StateBackend};
 use oct_cloud::aws::resource::{
     Ec2Instance, EcrRepository, HostedZone, InboundRule, InstanceProfile, InstanceRole,
     InternetGateway, RouteTable, SecurityGroup, Subnet, VPC,
 };
 use oct_cloud::aws::types::InstanceType;
-use oct_cloud::backend::{LocalStateBackend, S3StateBackend, StateBackend};
 use oct_cloud::resource::Resource;
 use oct_cloud::state;
 
+mod backend;
 mod config;
 mod oct_ctl_sdk;
 mod scheduler;


### PR DESCRIPTION
`backend` will be used for infra and user states

Related to #268