### PR TITLE
Add basic `run-examples` workflow

### DIFF
--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -1,0 +1,37 @@
+name: Test example projects
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  test-example-project:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        project:
+          - http-server-with-dockerfile
+          - http-server-with-multiple-dockerfiles
+          - inject-system-env-var
+          - multi-host-rest-service-with-lb
+          - ray-single-worker
+          - rest-service-with-domain
+          - s3-remote-state-storage
+          - single-host-rest-service-with-lb
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run opencloudtool Command
+        uses: opencloudtool/oct-action@v0.0.3
+        with:
+          command: "deploy"
+          working-directory: "./examples/projects/${{ matrix.project }}"


### PR DESCRIPTION
OCT github action is failing now because it requires AWS credentials.
They'll be added in the follow-up PRs. For now this workflow will fail

Related to #223
Related to #249