### PR TITLE
Implement base infra graph with single-parent connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
@@ -142,15 +142,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-config"
-version = "1.6.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a18fd934af6ae7ca52410d4548b98eb895aab0f1ea417d168d85db1434a141"
+checksum = "ebd9b83179adf8998576317ce47785948bcff399ec5b15f4dfbdedd44ddf5b92"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -178,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "687bc16bc431a8533fe0097c7f0182874767f920989d7260950172ae8e3c4465"
+checksum = "b68c2194a190e1efc999612792e25b1ab3abfefe4306494efaaabc25933c0cbe"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -190,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fcc8f365936c834db5514fc45aee5b1202d677e6b40e48468aaaa8183ca8c7"
+checksum = "08b5d4e069cbc868041a64bd68dc8cb39a0d79585cd6c5a24caa8c2d622121be"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -200,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b1d86e7705efe1be1b569bab41d4fa1e14e220b60a160f78de2db687add079"
+checksum = "dbfd150b5dbdb988bcc8fb1fe787eb6b7ee6180ca24da683b61ea5405f3d43ff"
 dependencies = [
  "bindgen",
  "cc",
@@ -213,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.7"
+version = "1.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c4063282c69991e57faab9e5cb21ae557e59f5b0fb285c196335243df8dc25c"
+checksum = "b2090e664216c78e766b6bac10fe74d2f451c02441d43484cd76ac9a295075f7"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -238,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ec2"
-version = "1.136.0"
+version = "1.148.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3588a07d1ee564be066ea27ed556e877f39bd8882abec6bf7f3ed8183eb6a08"
+checksum = "792e8dc45e88aedb7f91c8ba428b88d132011e95857e51c11e6fe8cbd9d33c64"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -261,9 +261,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ecr"
-version = "1.78.0"
+version = "1.84.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36a6c787ae5fa44bb47c3ae72c7bc740da29a1ea159a53005848905fdf4728a5"
+checksum = "378f480f044086980ef5a4ad6b461d231efea8af7bd578bf68c6525ead6c9141"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -283,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-iam"
-version = "1.75.0"
+version = "1.81.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5e25086a0d6f0f279d7c501c8ac81bb91f02f3c62344493c2a946a9c524bb6"
+checksum = "78727f686e7625a6b39c124878dd96e53c4f5b784b0d7ec4f8dfa317f1105d1f"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -306,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-route53"
-version = "1.79.0"
+version = "1.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3360549045a72633307506a7fc2fa9479d55c7ecbee3113547e92da650989b13"
+checksum = "ef2b3239c1444149b74f6f7ff3bc144f60e5d7569ccde530a08ea983fb429cff"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -328,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.90.0"
+version = "1.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5934beb9403c562bd129a1de1bd51ab67209c05ddf3a4a8c86714120181c860f"
+checksum = "029e89cae7e628553643aecb3a3f054a0a0912ff0fd1f5d6a0b4fda421dce64b"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -362,9 +362,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.71.0"
+version = "1.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a4fd09d6e863655d99cd2260f271c6d1030dc6bfad68e19e126d2e4c8ceb18"
+checksum = "64bf26698dd6d238ef1486bdda46f22a589dc813368ba868dc3d94c8d27b56ba"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -384,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.72.0"
+version = "1.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3224ab02ebb3074467a33d57caf6fcb487ca36f3697fdd381b0428dc72380696"
+checksum = "09cd07ed1edd939fae854a22054299ae3576500f4e0fadc560ca44f9c6ea1664"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -406,9 +406,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.72.0"
+version = "1.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6933f189ed1255e78175fbd73fb200c0aae7240d220ed3346f567b0ddca3083"
+checksum = "37f7766d2344f56d10d12f3c32993da36d78217f32594fe4fb8e57a538c1cdea"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -429,9 +429,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3734aecf9ff79aa401a6ca099d076535ab465ff76b46440cf567c8e70b65dc13"
+checksum = "ddfb9021f581b71870a17eac25b52335b82211cdc092e02b6876b2bcefa61666"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -468,9 +468,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.63.3"
+version = "0.63.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f77a921dbd2c78ebe70726799787c1d110a2245dd65e39b20923dfdfb2deee"
+checksum = "5ab9472f7a8ec259ddb5681d2ef1cb1cf16c0411890063e67cdc7b62562cc496"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -488,9 +488,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.8"
+version = "0.60.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c45d3dddac16c5c59d553ece225a88870cf81b7b813c9cc17b78cf4685eac7a"
+checksum = "604c7aec361252b8f1c871a7641d5e0ba3a7f5a586e51b66bc9510a5519594d9"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -499,9 +499,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.62.1"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99335bec6cdc50a346fda1437f9fefe33abf8c99060739a546a16457f2862ca9"
+checksum = "43c82ba4cab184ea61f6edaafc1072aad3c2a17dcf4c0fce19ac5694b90d8b5f"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
@@ -520,26 +520,26 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.0.3"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "073d330f94bdf1f47bb3e0f5d45dda1e372a54a553c39ab6e9646902c8c81594"
+checksum = "f108f1ca850f3feef3009bdcc977be201bca9a91058864d9de0684e64514bee0"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2 0.3.26",
- "h2 0.4.10",
+ "h2 0.3.27",
+ "h2 0.4.11",
  "http 0.2.12",
  "http 1.3.1",
  "http-body 0.4.6",
  "hyper 0.14.32",
  "hyper 1.6.0",
  "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.6",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls 0.23.27",
+ "rustls 0.23.29",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
@@ -549,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.61.3"
+version = "0.61.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92144e45819cae7dc62af23eac5a038a58aa544432d2102609654376a900bd07"
+checksum = "a16e040799d29c17412943bdbf488fd75db04112d0c0d4b9290bacf5ae0014b9"
 dependencies = [
  "aws-smithy-types",
 ]
@@ -577,9 +577,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14302f06d1d5b7d333fd819943075b13d27c7700b414f574c3c35859bfb55d5e"
+checksum = "c3aaec682eb189e43c8a19c3dab2fe54590ad5f2cc2d26ab27608a20f2acf81c"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -601,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.8.0"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e5d9e3a80a18afa109391fb5ad09c3daf887b516c6fd805a157c6ea7994a57"
+checksum = "9852b9226cb60b78ce9369022c0df678af1cac231c882d5da97a0c4e03be6e67"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -618,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40076bd09fadbc12d5e026ae080d0930defa606856186e31d83ccc6a255eeaf3"
+checksum = "d498595448e43de7f4296b7b7a18a8a02c61ec9349128c80a368f7c3b4ab11a8"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -644,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.60.9"
+version = "0.60.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab0b0166827aa700d3dc519f72f8b3a91c35d0b8d042dc5d643a91e6f80648fc"
+checksum = "3db87b96cb1b16c024980f133968d52882ca0daaee3a086c6decc500f6c99728"
 dependencies = [
  "xmlparser",
 ]
@@ -819,9 +819,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytes"
@@ -841,9 +841,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.25"
+version = "1.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
+checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
 dependencies = [
  "jobserver",
  "libc",
@@ -861,9 +861,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "chrono"
@@ -912,9 +912,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -922,9 +922,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -934,9 +934,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -946,9 +946,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "cmake"
@@ -1032,11 +1032,10 @@ checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc-fast"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68fcb2be5386ffb77e30bf10820934cb89a628bcb976e7cc632dcd88c059ebea"
+checksum = "6bf62af4cc77d8fe1c22dde4e721d87f2f54056139d8c412e1366b740305f56f"
 dependencies = [
- "cc",
  "crc",
  "digest",
  "libc",
@@ -1046,9 +1045,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -1259,12 +1258,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1282,6 +1281,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "float-cmp"
@@ -1397,7 +1402,7 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1461,9 +1466,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
 dependencies = [
  "bytes",
  "fnv",
@@ -1480,9 +1485,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1499,9 +1504,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1625,7 +1630,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2 0.3.27",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -1648,7 +1653,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.10",
+ "h2 0.4.11",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -1678,14 +1683,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.6"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a01595e11bdcec50946522c32dde3fc6914743000a68b93000965f2f02406d"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
- "rustls 0.23.27",
+ "rustls 0.23.29",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
@@ -1711,9 +1716,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
+checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1884,12 +1889,23 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1931,9 +1947,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a194df1107f33c79f4f93d02c80798520551949d59dfad22b6157048a88cca93"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
 dependencies = [
  "jiff-static",
  "log",
@@ -1944,9 +1960,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c6e1db7ed32c6c71b759497fae34bf7933636f75a251b9e736555da426f6442"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1987,9 +2003,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libloading"
@@ -1998,7 +2014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.0",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -2068,9 +2084,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "mime"
@@ -2086,9 +2102,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
@@ -2100,7 +2116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
 
@@ -2255,6 +2271,7 @@ dependencies = [
  "base64 0.22.1",
  "log",
  "mockall",
+ "petgraph",
  "serde",
  "tempfile",
  "tokio",
@@ -2413,9 +2430,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
+checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
  "thiserror",
@@ -2424,9 +2441,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
+checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2434,9 +2451,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
+checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2447,13 +2464,24 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
+checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
 dependencies = [
- "once_cell",
  "pest",
  "sha2",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54acf3a685220b533e437e264e4d932cfbdc4cc7ec0cd232ed73c08d03b8a7ca"
+dependencies = [
+ "fixedbitset",
+ "hashbrown",
+ "indexmap",
+ "serde",
 ]
 
 [[package]]
@@ -2524,9 +2552,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "portable-atomic-util"
@@ -2593,9 +2621,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.33"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dee91521343f4c5c6a63edd65e54f31f5c92fe8978c40a4282f8372194c6a7d"
+checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -2621,9 +2649,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -2686,9 +2714,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags",
 ]
@@ -2730,20 +2758,20 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.21"
+version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8cea6b35bcceb099f30173754403d2eba0a5dc18cea3630fccd88251909288"
+checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
- "h2 0.4.10",
+ "h2 0.4.11",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
- "hyper-rustls 0.27.6",
+ "hyper-rustls 0.27.7",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -2795,9 +2823,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustc-hash"
@@ -2829,15 +2857,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2854,14 +2882,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.27"
+version = "0.23.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
+checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki 0.103.3",
+ "rustls-webpki 0.103.4",
  "subtle",
  "zeroize",
 ]
@@ -2920,9 +2948,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3165,12 +3193,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "slug"
@@ -3184,9 +3209,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
@@ -3228,9 +3253,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3287,7 +3312,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "windows-sys 0.59.0",
 ]
 
@@ -3340,12 +3365,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -3390,17 +3414,19 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
+ "slab",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
@@ -3443,7 +3469,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.27",
+ "rustls 0.23.29",
  "tokio",
 ]
 
@@ -3562,9 +3588,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3573,9 +3599,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -3780,9 +3806,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -3954,15 +3980,15 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-registry"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bab093bdd303a1240bb99b8aba8ea8a69ee19d34c9e2ef9594e708a4878820"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
  "windows-link",
  "windows-result",
@@ -4006,6 +4032,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4023,9 +4058,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.0"
+version = "0.53.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
 dependencies = [
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
@@ -4135,9 +4170,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]
@@ -4189,18 +4224,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ aws-sdk-route53 = "1.67.0"
 aws-sdk-s3 = "1.78.0"
 axum = "0.8.4"
 base64 = "0.22.1"
-clap = { version = "4.5.40", features = ["derive"] }
+clap = { version = "4.5.41", features = ["derive"] }
+petgraph = "0.8.1"
 predicates = "3.1.3"
 serde = "1.0.219"
 serde_derive = "1.0.213"

--- a/crates/oct-cli/src/main.rs
+++ b/crates/oct-cli/src/main.rs
@@ -17,6 +17,10 @@ struct Cli {
     /// Context path
     #[clap(long, default_value = ".")]
     context_path: String,
+
+    /// Use infra graph for deployment
+    #[clap(long)]
+    use_infra_graph: bool,
 }
 
 #[derive(Subcommand)]
@@ -34,10 +38,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
     let orchestrator = oct_orchestrator::Orchestrator;
+    let orchestrator_with_graph = oct_orchestrator::OrchestratorWithGraph;
 
-    match &cli.command {
-        Commands::Deploy => Box::pin(orchestrator.deploy()).await?,
-        Commands::Destroy => orchestrator.destroy().await?,
+    if cli.use_infra_graph {
+        match &cli.command {
+            Commands::Deploy => orchestrator_with_graph.deploy().await?,
+            Commands::Destroy => orchestrator_with_graph.destroy().await?,
+        }
+    } else {
+        match &cli.command {
+            Commands::Deploy => Box::pin(orchestrator.deploy()).await?,
+            Commands::Destroy => orchestrator.destroy().await?,
+        }
     }
 
     Ok(())
@@ -59,6 +71,16 @@ mod tests {
         assert_eq!(cli.user_state_file_path, "./user_state.json");
         assert_eq!(cli.dockerfile_path, ".");
         assert_eq!(cli.context_path, ".");
+        assert!(!cli.use_infra_graph);
+    }
+
+    #[test]
+    fn test_cli_use_infra_graph_flag() {
+        // Arrange
+        let cli = Cli::parse_from(["app", "--use-infra-graph", "deploy"]);
+
+        // Assert
+        assert!(cli.use_infra_graph);
     }
 
     #[tokio::test]

--- a/crates/oct-cloud/Cargo.toml
+++ b/crates/oct-cloud/Cargo.toml
@@ -13,6 +13,7 @@ aws-sdk-s3 = { workspace = true }
 base64 = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 serde = { workspace = true, features = ["derive"] }
+petgraph = { workspace = true }
 log = { workspace = true }
 uuid = { workspace = true }
 

--- a/crates/oct-cloud/src/aws/mod.rs
+++ b/crates/oct-cloud/src/aws/mod.rs
@@ -1,4 +1,4 @@
 pub mod resource;
 pub mod types;
 
-mod client;
+pub mod client;

--- a/crates/oct-cloud/src/aws/resource.rs
+++ b/crates/oct-cloud/src/aws/resource.rs
@@ -411,9 +411,9 @@ impl Resource for Ec2Instance {
                 self.instance_type.clone(),
                 self.ami.clone(),
                 self.user_data_base64.clone(),
-                self.instance_profile_name.clone(),
+                Some(self.instance_profile_name.clone()),
                 self.subnet_id.clone(),
-                self.security_group_id.clone(),
+                Some(self.security_group_id.clone()),
             )
             .await?;
 
@@ -1577,9 +1577,9 @@ mod tests {
                 eq(InstanceType::T2Micro),
                 eq("ami-830c94e3".to_string()),
                 eq("test".to_string()),
-                eq("instance_profile".to_string()),
+                eq(Some("instance_profile".to_string())),
                 eq("subnet-12345".to_string()),
-                eq("sg-12345".to_string()),
+                eq(Some("sg-12345".to_string())),
             )
             .return_once(|_, _, _, _, _, _| {
                 Ok(RunInstancesOutput::builder()
@@ -1630,9 +1630,9 @@ mod tests {
                 eq(InstanceType::T2Micro),
                 eq("ami-830c94e3".to_string()),
                 eq("test".to_string()),
-                eq("instance_profile".to_string()),
+                eq(Some("instance_profile".to_string())),
                 eq("subnet-12345".to_string()),
-                eq("sg-12345".to_string()),
+                eq(Some("sg-12345".to_string())),
             )
             .return_once(|_, _, _, _, _, _| Ok(RunInstancesOutput::builder().build()));
 

--- a/crates/oct-cloud/src/graph.rs
+++ b/crates/oct-cloud/src/graph.rs
@@ -1,0 +1,759 @@
+use aws_sdk_ec2::types::InstanceStateName;
+use base64::{Engine as _, engine::general_purpose};
+use petgraph::visit::NodeIndexable;
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, VecDeque};
+
+use petgraph::Graph;
+use petgraph::dot::Dot;
+use petgraph::graph::NodeIndex;
+
+use crate::aws::client;
+use crate::aws::types;
+
+/// Defines the main methods to manage resources
+trait Manager<'a, I, O>
+where
+    I: 'a + Send + Sync,
+    O: 'a + Send + Sync,
+{
+    fn create(
+        &self,
+        input: &'a I,
+        parents: Vec<&'a Node>,
+    ) -> impl std::future::Future<Output = Result<O, Box<dyn std::error::Error>>> + Send;
+
+    fn destroy(
+        &self,
+        input: &'a O,
+    ) -> impl std::future::Future<Output = Result<(), Box<dyn std::error::Error>>> + Send;
+}
+
+#[derive(Debug)]
+pub struct VpcSpec {
+    region: String,
+    cidr_block: String,
+    name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Vpc {
+    id: String,
+
+    region: String,
+    cidr_block: String,
+    name: String,
+    igw_id: String,
+}
+
+struct VpcManager<'a> {
+    client: &'a client::Ec2,
+}
+
+impl Manager<'_, VpcSpec, Vpc> for VpcManager<'_> {
+    async fn create(
+        &self,
+        input: &'_ VpcSpec,
+        _parents: Vec<&Node>,
+    ) -> Result<Vpc, Box<dyn std::error::Error>> {
+        let vpc_id = self
+            .client
+            .create_vpc(input.cidr_block.clone(), input.name.clone())
+            .await?;
+
+        let igw_id = self.client.create_internet_gateway(vpc_id.clone()).await?;
+
+        let default_security_group_id = self
+            .client
+            .get_default_security_group_id(vpc_id.clone())
+            .await?;
+
+        let inbound_rules = vec![
+            (String::from("0.0.0.0/0"), String::from("tcp"), 80),
+            (String::from("0.0.0.0/0"), String::from("tcp"), 31888),
+            (String::from("0.0.0.0/0"), String::from("tcp"), 22),
+        ];
+
+        for (cidr_block, protocol, port) in inbound_rules {
+            self.client
+                .allow_inbound_traffic_for_security_group(
+                    default_security_group_id.clone(),
+                    protocol,
+                    port,
+                    cidr_block,
+                )
+                .await?;
+        }
+
+        Ok(Vpc {
+            id: vpc_id,
+            region: input.region.clone(),
+            cidr_block: input.cidr_block.clone(),
+            name: input.name.clone(),
+            igw_id,
+        })
+    }
+
+    async fn destroy(&self, input: &'_ Vpc) -> Result<(), Box<dyn std::error::Error>> {
+        self.client
+            .delete_internet_gateway(input.igw_id.clone(), input.id.clone())
+            .await?;
+
+        self.client.delete_vpc(input.id.clone()).await
+    }
+}
+
+#[derive(Debug)]
+pub struct SubnetSpec {
+    name: String,
+    cidr_block: String,
+    availability_zone: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Subnet {
+    id: String,
+
+    name: String,
+    cidr_block: String,
+    availability_zone: String,
+
+    route_table_id: String,
+}
+
+struct SubnetManager<'a> {
+    client: &'a client::Ec2,
+}
+
+impl Manager<'_, SubnetSpec, Subnet> for SubnetManager<'_> {
+    async fn create(
+        &self,
+        input: &'_ SubnetSpec,
+        parents: Vec<&Node>,
+    ) -> Result<Subnet, Box<dyn std::error::Error>> {
+        let vpc_node = parents
+            .iter()
+            .find(|parent| matches!(parent, Node::Resource(ResourceType::Vpc(_))));
+
+        let vpc = if let Some(Node::Resource(ResourceType::Vpc(vpc))) = vpc_node {
+            Ok(vpc.clone())
+        } else {
+            Err("Unexpected parent")
+        }?;
+
+        let subnet_id = self
+            .client
+            .create_subnet(
+                vpc.id.clone(),
+                input.cidr_block.clone(),
+                input.availability_zone.clone(),
+                input.name.clone(),
+            )
+            .await?;
+
+        self.client
+            .enable_auto_assign_ip_addresses_for_subnet(subnet_id.clone())
+            .await?;
+
+        let route_table_id = self.client.create_route_table(vpc.id.clone()).await?;
+
+        self.client
+            .associate_route_table_with_subnet(route_table_id.clone(), subnet_id.clone())
+            .await?;
+
+        self.client
+            .add_public_route(route_table_id.clone(), vpc.igw_id.clone())
+            .await?;
+
+        Ok(Subnet {
+            id: subnet_id,
+            name: input.name.clone(),
+            cidr_block: input.cidr_block.clone(),
+            availability_zone: input.availability_zone.clone(),
+            route_table_id: route_table_id.clone(),
+        })
+    }
+
+    async fn destroy(&self, input: &'_ Subnet) -> Result<(), Box<dyn std::error::Error>> {
+        self.client
+            .disassociate_route_table_with_subnet(input.route_table_id.clone(), input.id.clone())
+            .await?;
+
+        self.client
+            .delete_route_table(input.route_table_id.clone())
+            .await?;
+
+        self.client.delete_subnet(input.id.clone()).await
+    }
+}
+
+#[derive(Debug)]
+pub struct VmSpec {
+    instance_type: types::InstanceType,
+    ami: String,
+    user_data: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Vm {
+    pub id: String,
+    pub public_ip: String,
+
+    pub instance_type: types::InstanceType,
+    ami: String,
+    user_data: String,
+}
+
+struct VmManager<'a> {
+    client: &'a client::Ec2,
+}
+
+impl VmManager<'_> {
+    /// TODO: Move the full VM initialization logic to client
+    async fn get_public_ip(&self, instance_id: &str) -> Option<String> {
+        const MAX_ATTEMPTS: usize = 10;
+        const SLEEP_DURATION: std::time::Duration = std::time::Duration::from_secs(5);
+
+        for _ in 0..MAX_ATTEMPTS {
+            if let Ok(instance) = self
+                .client
+                .describe_instances(String::from(instance_id))
+                .await
+            {
+                if let Some(public_ip) = instance.public_ip_address() {
+                    return Some(public_ip.to_string());
+                }
+            }
+
+            tokio::time::sleep(SLEEP_DURATION).await;
+        }
+
+        None
+    }
+
+    async fn is_terminated(&self, id: String) -> Result<(), Box<dyn std::error::Error>> {
+        let max_attempts = 24;
+        let sleep_duration = 5;
+
+        log::info!("Waiting for VM {id:?} to be terminated...");
+
+        for _ in 0..max_attempts {
+            let vm = self.client.describe_instances(id.clone()).await?;
+
+            let vm_status = vm.state().and_then(|s| s.name());
+
+            if vm_status == Some(&InstanceStateName::Terminated) {
+                log::info!("VM {id:?} terminated");
+                return Ok(());
+            }
+
+            log::info!(
+                "VM is not terminated yet... \
+                 retrying in {sleep_duration} sec...",
+            );
+            tokio::time::sleep(std::time::Duration::from_secs(sleep_duration)).await;
+        }
+
+        Err("VM failed to terminate".into())
+    }
+}
+
+impl Manager<'_, VmSpec, Vm> for VmManager<'_> {
+    async fn create(
+        &self,
+        input: &'_ VmSpec,
+        parents: Vec<&Node>,
+    ) -> Result<Vm, Box<dyn std::error::Error>> {
+        let subnet_node = parents
+            .iter()
+            .find(|parent| matches!(parent, Node::Resource(ResourceType::Subnet(_))));
+
+        let subnet_id = if let Some(Node::Resource(ResourceType::Subnet(subnet))) = subnet_node {
+            Ok(subnet.id.clone())
+        } else {
+            Err("Unexpected parent")
+        };
+
+        let user_data_base64 = general_purpose::STANDARD.encode(input.user_data.clone());
+
+        let response = self
+            .client
+            .run_instances(
+                input.instance_type.clone(),
+                input.ami.clone(),
+                user_data_base64,
+                None,
+                subnet_id?,
+                None,
+            )
+            .await?;
+
+        let instance = response
+            .instances()
+            .first()
+            .ok_or("No instances returned")?;
+
+        let instance_id = instance.instance_id.as_ref().ok_or("No instance id")?;
+
+        let public_ip = self
+            .get_public_ip(instance_id)
+            .await
+            .expect("In this implementation we always expect public ip");
+
+        Ok(Vm {
+            id: instance_id.clone(),
+            public_ip,
+
+            instance_type: input.instance_type.clone(),
+            ami: input.ami.clone(),
+            user_data: input.user_data.clone(),
+        })
+    }
+
+    async fn destroy(&self, input: &'_ Vm) -> Result<(), Box<dyn std::error::Error>> {
+        self.client.terminate_instance(input.id.clone()).await?;
+
+        self.is_terminated(input.id.clone()).await
+    }
+}
+
+#[derive(Debug)]
+pub enum ResourceSpecType {
+    Vpc(VpcSpec),
+    Subnet(SubnetSpec),
+    Vm(VmSpec),
+}
+
+#[derive(Debug, Default)]
+pub enum SpecNode {
+    /// The synthetic root node.
+    #[default]
+    Root,
+    /// A resource spec in the dependency graph.
+    Resource(ResourceSpecType),
+}
+
+impl std::fmt::Display for SpecNode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SpecNode::Root => write!(f, "Root"),
+            SpecNode::Resource(resource_type) => match resource_type {
+                ResourceSpecType::Vpc(resource) => {
+                    write!(f, "spec {}", resource.name)
+                }
+                ResourceSpecType::Subnet(resource) => {
+                    write!(f, "spec {}", resource.cidr_block)
+                }
+                ResourceSpecType::Vm(_resource) => {
+                    write!(f, "spec VM")
+                }
+            },
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub enum ResourceType {
+    #[default] // TODO: Remove
+    None,
+
+    Vpc(Vpc),
+    Subnet(Subnet),
+    Vm(Vm),
+}
+
+impl ResourceType {
+    fn name(&self) -> String {
+        match self {
+            ResourceType::Vpc(vpc) => format!("vpc.{}", vpc.name),
+            ResourceType::Subnet(subnet) => format!("subnet.{}", subnet.name),
+            ResourceType::Vm(vm) => format!("vm.{}", vm.id),
+            ResourceType::None => String::from("none"),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub enum Node {
+    /// The synthetic root node.
+    #[default]
+    Root,
+    /// A cloud resource in the dependency graph.
+    Resource(ResourceType),
+}
+
+impl std::fmt::Display for Node {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Node::Root => write!(f, "Root"),
+            Node::Resource(resource_type) => match resource_type {
+                ResourceType::Vpc(resource) => {
+                    write!(f, "cloud {}", resource.name)
+                }
+                ResourceType::Subnet(resource) => {
+                    write!(f, "cloud {}", resource.cidr_block)
+                }
+                ResourceType::Vm(resource) => {
+                    write!(f, "cloud VM {}", resource.id)
+                }
+                ResourceType::None => {
+                    write!(f, "cloud None")
+                }
+            },
+        }
+    }
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct State {
+    resources: Vec<ResourceState>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct ResourceState {
+    name: String,
+    resource: ResourceType,
+    dependencies: Vec<String>,
+}
+
+impl State {
+    pub fn from_graph(graph: &Graph<Node, String>) -> Self {
+        let mut resource_states: Vec<ResourceState> = Vec::new();
+
+        let mut queue: VecDeque<(NodeIndex, NodeIndex)> = VecDeque::new();
+        let root_node = graph.from_index(0);
+        for node_index in graph.neighbors(root_node) {
+            queue.push_back((node_index, root_node));
+        }
+
+        while let Some((node_index, parent_node_index)) = queue.pop_front() {
+            let parent_node = graph
+                .node_weight(parent_node_index)
+                .expect("Failed to get parent");
+
+            let dependencies = match parent_node {
+                Node::Root => Vec::new(),
+                Node::Resource(parent_resource_type) => vec![parent_resource_type.name()],
+            };
+
+            if let Some(Node::Resource(resource_type)) = graph.node_weight(node_index) {
+                log::info!("Add to state {resource_type:?}");
+
+                resource_states.push(ResourceState {
+                    name: resource_type.name(),
+                    resource: resource_type.clone(),
+                    dependencies,
+                });
+
+                for neighbor_node_index in graph.neighbors(node_index) {
+                    queue.push_back((neighbor_node_index, node_index));
+                }
+            }
+        }
+
+        Self {
+            resources: resource_states,
+        }
+    }
+
+    pub fn to_graph(&self) -> Graph<Node, String> {
+        let mut graph = Graph::<Node, String>::new();
+        let mut edges = Vec::new();
+        let root = graph.add_node(Node::Root);
+
+        let mut resources_map: HashMap<String, NodeIndex> = HashMap::new();
+        for resource_state in &self.resources {
+            let node = graph.add_node(Node::Resource(resource_state.resource.clone()));
+
+            resources_map.insert(resource_state.name.clone(), node);
+        }
+
+        for resource_state in &self.resources {
+            let resource = resources_map
+                .get(&resource_state.name)
+                .expect("Missed resource value in resource_map");
+
+            let dependency = resource_state.dependencies.first();
+
+            match dependency {
+                None => edges.push((root, *resource, String::new())),
+                Some(dependency_name) => {
+                    let dependency_resource = resources_map
+                        .get(dependency_name)
+                        .expect("Missed dependency resource value in resource_map");
+
+                    edges.push((*dependency_resource, *resource, String::new()));
+                }
+            }
+        }
+
+        graph.extend_with_edges(&edges);
+
+        graph
+    }
+}
+
+pub struct GraphManager {
+    ec2_client: client::Ec2,
+}
+
+impl GraphManager {
+    pub async fn new() -> Self {
+        let region_provider = aws_sdk_ec2::config::Region::new("us-west-2");
+        let config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+            .credentials_provider(
+                aws_config::profile::ProfileFileCredentialsProvider::builder()
+                    .profile_name("default")
+                    .build(),
+            )
+            .region(region_provider)
+            .load()
+            .await;
+
+        let ec2_client = client::Ec2::new(aws_sdk_ec2::Client::new(&config));
+
+        Self { ec2_client }
+    }
+
+    pub fn get_spec_graph(
+        number_of_instances: u32,
+        instance_type: &types::InstanceType,
+    ) -> Graph<SpecNode, String> {
+        let mut deps = Graph::<SpecNode, String>::new();
+        let root = deps.add_node(SpecNode::Root);
+
+        let vpc_1 = deps.add_node(SpecNode::Resource(ResourceSpecType::Vpc(VpcSpec {
+            region: String::from("us-west-2"),
+            cidr_block: String::from("10.0.0.0/16"),
+            name: String::from("vpc-1"),
+        })));
+
+        let subnet_1 = deps.add_node(SpecNode::Resource(ResourceSpecType::Subnet(SubnetSpec {
+            name: String::from("vpc-1-subnet"),
+            cidr_block: String::from("10.0.1.0/24"),
+            availability_zone: String::from("us-west-2a"),
+        })));
+
+        let user_data = String::from(
+            r#"#!/bin/bash
+        set -e
+        sudo apt update
+        sudo apt -y install podman
+        sudo systemctl start podman
+
+        curl \
+            --output /home/ubuntu/oct-ctl \
+            -L \
+            https://github.com/opencloudtool/opencloudtool/releases/download/tip/oct-ctl \
+            && sudo chmod +x /home/ubuntu/oct-ctl \
+            && /home/ubuntu/oct-ctl &
+        "#,
+        );
+
+        // TODO: Add instance profile with instance role
+        let instances = (0..number_of_instances)
+            .collect::<Vec<u32>>()
+            .into_iter()
+            .map(|_| {
+                deps.add_node(SpecNode::Resource(ResourceSpecType::Vm(VmSpec {
+                    instance_type: instance_type.clone(),
+                    ami: String::from("ami-04dd23e62ed049936"),
+                    user_data: user_data.clone(),
+                })))
+            });
+
+        let mut edges = vec![
+            (root, vpc_1, String::new()),
+            (vpc_1, subnet_1, String::new()),
+        ];
+        for instance in instances {
+            edges.push((subnet_1, instance, String::new()));
+        }
+
+        deps.extend_with_edges(&edges);
+
+        deps
+    }
+
+    /// Deploy spec graph
+    ///
+    /// Temporarily also returns a list of VMs to be used for user
+    /// services deployment
+    /// TODO: Implement graph manager
+    pub async fn deploy(&self, graph: &Graph<SpecNode, String>) -> (Graph<Node, String>, Vec<Vm>) {
+        let mut resource_graph = Graph::<Node, String>::new();
+        let mut edges = vec![];
+        let root = resource_graph.add_node(Node::Root);
+
+        let mut queue: VecDeque<(NodeIndex, NodeIndex)> = VecDeque::new();
+        let root_node = graph.from_index(0);
+        for node_index in graph.neighbors(root_node) {
+            queue.push_back((node_index, root));
+        }
+
+        let mut vms: Vec<Vm> = Vec::new();
+
+        while let Some((node_index, parent_node_index)) = queue.pop_front() {
+            let parent_node = resource_graph
+                .node_weight(parent_node_index)
+                .expect("Failed to get parent");
+
+            if let Some(elem) = graph.node_weight(node_index) {
+                let created_resource_node_index = match elem {
+                    SpecNode::Root => Some(resource_graph.add_node(Node::Root)),
+                    SpecNode::Resource(resource_type) => match resource_type {
+                        ResourceSpecType::Vpc(resource) => {
+                            let manager = VpcManager {
+                                client: &self.ec2_client,
+                            };
+                            let output_vpc = manager.create(resource, vec![parent_node]).await;
+
+                            match output_vpc {
+                                Ok(output_vpc) => {
+                                    log::info!(
+                                        "Deployed {output_vpc:?}, parent - {parent_node_index:?}"
+                                    );
+
+                                    let node = Node::Resource(ResourceType::Vpc(output_vpc));
+                                    let vpc_index = resource_graph.add_node(node.clone());
+
+                                    edges.push((parent_node_index, vpc_index, String::new()));
+
+                                    Some(vpc_index)
+                                }
+                                Err(_) => None,
+                            }
+                        }
+                        ResourceSpecType::Subnet(resource) => {
+                            let manager = SubnetManager {
+                                client: &self.ec2_client,
+                            };
+                            let output_subnet = manager.create(resource, vec![parent_node]).await;
+
+                            match output_subnet {
+                                Ok(output_subnet) => {
+                                    log::info!(
+                                        "Deployed {output_subnet:?}, parent - {parent_node_index:?}"
+                                    );
+
+                                    let node = Node::Resource(ResourceType::Subnet(output_subnet));
+                                    let subnet_index = resource_graph.add_node(node.clone());
+
+                                    edges.push((parent_node_index, subnet_index, String::new()));
+
+                                    Some(subnet_index)
+                                }
+                                Err(_) => None,
+                            }
+                        }
+                        ResourceSpecType::Vm(resource) => {
+                            let manager = VmManager {
+                                client: &self.ec2_client,
+                            };
+                            let output_vm = manager.create(resource, vec![parent_node]).await;
+
+                            match output_vm {
+                                Ok(output_vm) => {
+                                    log::info!(
+                                        "Deployed {output_vm:?}, parent - {parent_node_index:?}"
+                                    );
+
+                                    let node = Node::Resource(ResourceType::Vm(output_vm.clone()));
+                                    let vm_index = resource_graph.add_node(node.clone());
+
+                                    edges.push((parent_node_index, vm_index, String::new()));
+
+                                    vms.push(output_vm);
+
+                                    Some(vm_index)
+                                }
+                                Err(_) => None,
+                            }
+                        }
+                    },
+                };
+
+                let Some(created_resource_node_index) = created_resource_node_index else {
+                    //TODO: Handle failed resource creation
+                    log::error!("Failed to create a resource");
+
+                    continue;
+                };
+
+                for neighbor_index in graph.neighbors(node_index) {
+                    queue.push_back((neighbor_index, created_resource_node_index));
+                }
+            }
+        }
+
+        resource_graph.extend_with_edges(&edges);
+
+        log::info!("Created graph {}", Dot::new(&resource_graph));
+
+        (resource_graph, vms)
+    }
+
+    pub async fn destroy(&self, graph: &Graph<Node, String>) {
+        log::info!("Graph to delete {}", Dot::new(&graph));
+
+        // Remove resources
+        let mut queue_to_destroy: VecDeque<NodeIndex> = VecDeque::new();
+        let mut queue_to_traverse: VecDeque<NodeIndex> = VecDeque::new();
+        let root_node = graph.from_index(0);
+        for node_index in graph.neighbors(root_node) {
+            queue_to_traverse.push_back(node_index);
+        }
+
+        // Prepare queue to destroy
+        while let Some(node_index) = queue_to_traverse.pop_front() {
+            if let Some(_elem) = graph.node_weight(node_index) {
+                queue_to_destroy.push_back(node_index);
+
+                for neighbor_index in graph.neighbors(node_index) {
+                    queue_to_traverse.push_back(neighbor_index);
+                }
+            }
+        }
+
+        // Destroy resources from back
+        while let Some(node_index) = queue_to_destroy.pop_back() {
+            if let Some(elem) = graph.node_weight(node_index) {
+                match elem {
+                    Node::Root => {}
+                    Node::Resource(resource_type) => match resource_type {
+                        ResourceType::Vpc(resource) => {
+                            let manager = VpcManager {
+                                client: &self.ec2_client,
+                            };
+                            let _ = manager.destroy(resource).await;
+
+                            log::info!("Destroyed {resource:?}");
+                        }
+                        ResourceType::Subnet(resource) => {
+                            let manager = SubnetManager {
+                                client: &self.ec2_client,
+                            };
+                            let _ = manager.destroy(resource).await;
+
+                            log::info!("Destroyed {resource:?}");
+                        }
+                        ResourceType::Vm(resource) => {
+                            let manager = VmManager {
+                                client: &self.ec2_client,
+                            };
+                            let _ = manager.destroy(resource).await;
+
+                            log::info!("Destroyed {resource:?}");
+                        }
+                        ResourceType::None => {
+                            panic!("Unexpected case ResourceType::None")
+                        }
+                    },
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {}

--- a/crates/oct-cloud/src/lib.rs
+++ b/crates/oct-cloud/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod graph;
 pub mod resource;
 pub mod state;
 


### PR DESCRIPTION
* Implement base infra graph with single-parent connections.
  * Add `VPC` (with nested `Internet Gateway`), `Subnet` (with nested `Route Table`) and `VM` resources
  * Add `GraphManager` with methods to create graph, deploy and destroy
  * Add `OrchestratorWithGraph` as a future replacement for `Orchestrator`
  * Add `State` with `to_graph` and `from_graph` methods to manage resource graph as a state
* Add `--use_infra_graph` feature flag to switch between `OrchestratorWithGraph` and legacy `Orchestrator`
  * `cargo run -p oct-cli -- --use_infra_graph deploy`
  * `cargo run -p oct-cli -- --use_infra_graph destroy`
* Add `petgraph` crate
* Update `clap` crate version to `4.5.41`

Tested on [single-host-rest-service-with-lb](https://github.com/opencloudtool/opencloudtool/tree/main/examples/projects/single-host-rest-service-with-lb) and [multi-host-rest-service-with-lb](https://github.com/opencloudtool/opencloudtool/tree/main/examples/projects/multi-host-rest-service-with-lb) examples.

It`s a preview version that is not covered with tests. The code will be refined and covered with tests later in the follow-up PRs

Related to #347