### PR TITLE
Add a 100 GiB EBS volume configuration to EC2 instance.

### DIFF
--- a/crates/oct-cloud/src/aws/client.rs
+++ b/crates/oct-cloud/src/aws/client.rs
@@ -591,7 +591,19 @@ impl Ec2Impl {
             .user_data(user_data_base64.clone())
             .subnet_id(subnet_id)
             .min_count(1)
-            .max_count(1);
+            .max_count(1)
+            .block_device_mappings(
+                aws_sdk_ec2::types::BlockDeviceMapping::builder()
+                    .device_name("/dev/sda1")
+                    .ebs(
+                        aws_sdk_ec2::types::EbsBlockDevice::builder()
+                            .volume_size(100)
+                            .volume_type(aws_sdk_ec2::types::VolumeType::Gp3)
+                            .delete_on_termination(true)
+                            .build(),
+                    )
+                    .build(),
+            );
 
         if let Some(instance_profile_name) = instance_profile_name {
             request = request.iam_instance_profile(

--- a/crates/oct-orchestrator/src/lib.rs
+++ b/crates/oct-orchestrator/src/lib.rs
@@ -20,7 +20,7 @@ mod user_state;
 pub struct OrchestratorWithGraph;
 
 impl OrchestratorWithGraph {
-    const INSTANCE_TYPE: InstanceType = InstanceType::T2Micro;
+    const INSTANCE_TYPE: InstanceType = InstanceType::T3Medium;
 
     pub async fn deploy(&self) -> Result<(), Box<dyn std::error::Error>> {
         let config = config::Config::new(None)?;


### PR DESCRIPTION
- Update `run_instances` method to attach a default 100 GiB `gp3` EBS volume to EC2 instance. 
- Make `InstanceType::T3Medium` default instance type for deployment via graph.