### PR TITLE
Remove `CODECOV_TOKEN` usage from postsubmit.yml

### DIFF
--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -94,7 +94,5 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: ./coverage.lcov
-          token: ${{ secrets.CODECOV_TOKEN }}
           slug: opencloudtool/opencloudtool
           fail_ci_if_error: true
-


### PR DESCRIPTION
It's not required

<img width="1008" height="241" alt="image" src="https://github.com/user-attachments/assets/361e6313-d0cb-4916-98c8-48a8d3d0634e" />
