### PR TITLE
Add `InstanceRole` resource to graph

### DIFF
--- a/crates/oct-cloud/src/aws/client.rs
+++ b/crates/oct-cloud/src/aws/client.rs
@@ -902,7 +902,7 @@ impl Route53Impl {
 
 /// AWS IAM client implementation
 #[derive(Debug)]
-pub(super) struct IAMImpl {
+pub struct IAMImpl {
     inner: aws_sdk_iam::Client,
 }
 
@@ -910,11 +910,11 @@ pub(super) struct IAMImpl {
 #[cfg_attr(test, allow(dead_code))]
 #[cfg_attr(test, automock)]
 impl IAMImpl {
-    pub(super) fn new(inner: aws_sdk_iam::Client) -> Self {
+    pub fn new(inner: aws_sdk_iam::Client) -> Self {
         Self { inner }
     }
 
-    pub(super) async fn create_instance_iam_role(
+    pub async fn create_instance_iam_role(
         &self,
         name: String,
         assume_role_policy: String,
@@ -948,7 +948,7 @@ impl IAMImpl {
         Ok(())
     }
 
-    pub(super) async fn delete_instance_iam_role(
+    pub async fn delete_instance_iam_role(
         &self,
         name: String,
         policy_arns: Vec<String>,
@@ -1116,9 +1116,9 @@ pub use Ec2Impl as Ec2;
 pub use MockEc2Impl as Ec2;
 
 #[cfg(not(test))]
-pub(super) use IAMImpl as IAM;
+pub use IAMImpl as IAM;
 #[cfg(test)]
-pub(super) use MockIAMImpl as IAM;
+pub use MockIAMImpl as IAM;
 
 #[cfg(not(test))]
 pub(super) use ECRImpl as ECR;


### PR DESCRIPTION
For now it's directly connected to `Vm` resource on the graph level. In the follow-up PR `InstanceRole` become a parent of `InstanceProfile` which will be the parent of `Vm`

Current graph:
<img width="3462" height="2777" alt="image" src="https://github.com/user-attachments/assets/688f8469-b371-4196-aff7-a973d0cc7740" />
