### PR TITLE
Attach security group to VM in infra graph

### DIFF
--- a/crates/oct-cloud/src/aws/client.rs
+++ b/crates/oct-cloud/src/aws/client.rs
@@ -579,11 +579,11 @@ impl Ec2Impl {
         user_data_base64: String,
         instance_profile_name: String,
         subnet_id: String,
-        security_group_id: Option<String>, // TODO: Remove `Option`
+        security_group_id: String,
     ) -> Result<RunInstancesOutput, Box<dyn std::error::Error>> {
         log::info!("Starting EC2 instance");
 
-        let mut request = self
+        let request = self
             .inner
             .run_instances()
             .instance_type(instance_type.as_str().into())
@@ -608,11 +608,8 @@ impl Ec2Impl {
                 aws_sdk_ec2::types::IamInstanceProfileSpecification::builder()
                     .name(instance_profile_name)
                     .build(),
-            );
-
-        if let Some(security_group_id) = security_group_id {
-            request = request.security_group_ids(security_group_id);
-        }
+            )
+            .security_group_ids(security_group_id);
 
         let response = request.send().await?;
 

--- a/crates/oct-cloud/src/aws/resource.rs
+++ b/crates/oct-cloud/src/aws/resource.rs
@@ -413,7 +413,7 @@ impl Resource for Ec2Instance {
                 self.user_data_base64.clone(),
                 self.instance_profile_name.clone(),
                 self.subnet_id.clone(),
-                Some(self.security_group_id.clone()),
+                self.security_group_id.clone(),
             )
             .await?;
 
@@ -1577,9 +1577,9 @@ mod tests {
                 eq(InstanceType::T2Micro),
                 eq("ami-830c94e3".to_string()),
                 eq("test".to_string()),
-                eq(Some("instance_profile".to_string())),
+                eq("instance_profile".to_string()),
                 eq("subnet-12345".to_string()),
-                eq(Some("sg-12345".to_string())),
+                eq("sg-12345".to_string()),
             )
             .return_once(|_, _, _, _, _, _| {
                 Ok(RunInstancesOutput::builder()
@@ -1630,9 +1630,9 @@ mod tests {
                 eq(InstanceType::T2Micro),
                 eq("ami-830c94e3".to_string()),
                 eq("test".to_string()),
-                eq(Some("instance_profile".to_string())),
+                eq("instance_profile".to_string()),
                 eq("subnet-12345".to_string()),
-                eq(Some("sg-12345".to_string())),
+                eq("sg-12345".to_string()),
             )
             .return_once(|_, _, _, _, _, _| Ok(RunInstancesOutput::builder().build()));
 


### PR DESCRIPTION
* Remove default security group usage
* Make `security_group_id` required in `run_instances`
* Fix failing tests