### PR TITLE
Add cargo `package` information to `Cargo.toml`s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2248,7 +2248,7 @@ dependencies = [
 
 [[package]]
 name = "oct-cli"
-version = "0.1.0"
+version = "0.4.1"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -2260,7 +2260,7 @@ dependencies = [
 
 [[package]]
 name = "oct-cloud"
-version = "0.1.0"
+version = "0.4.1"
 dependencies = [
  "aws-config",
  "aws-sdk-ec2",
@@ -2280,7 +2280,7 @@ dependencies = [
 
 [[package]]
 name = "oct-ctl"
-version = "0.1.0"
+version = "0.4.1"
 dependencies = [
  "axum",
  "log",
@@ -2296,7 +2296,7 @@ dependencies = [
 
 [[package]]
 name = "oct-orchestrator"
-version = "0.1.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,33 @@
+[workspace.package]
+name = "opencloudtool"
+version = "0.4.1"
+authors = ["opencloudtool Contributors"]
+categories = ["command-line-utilities"]
+documentation = "https://opencloudtool.com/docs"
+edition = "2024"
+homepage = "https://opencloudtool.com"
+# Keep `/` in front of `README.md` to exclude localized readmes
+include = [
+  "src/**/*",
+  "LICENSE",
+  "/README.md",
+]
+keywords = []
+license = "Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/opencloudtool/opencloudtool"
+rust-version = "1.87"
+description = """
+opencloudtool (oct)
+"""
+
 [workspace]
 members = ["crates/*"]
 resolver = "3"
 
 [workspace.dependencies]
-oct-cloud = { path = "crates/oct-cloud" }
-oct-orchestrator = { path = "crates/oct-orchestrator" }
+oct-cloud = { package = "oct-cloud", path = "crates/oct-cloud", version = "0.4.1" }
+oct-orchestrator = { package = "oct-orchestrator", path = "crates/oct-orchestrator", version = "0.4.1" }
 
 assert_cmd = "2.0.17"
 async-trait = "0.1.88"
@@ -23,7 +46,7 @@ serde = "1.0.219"
 serde_derive = "1.0.213"
 serde_json = "1.0.142"
 tempfile = "3.20.0"
-tera = { git = "https://github.com/minev-dev/tera.git", rev = "1e36d2f8ba66833ce9ad2b46044e21f8240b5299" } # Contains custom logic to render variables ignoring unknown variables
+tera = { git = "https://github.com/minev-dev/tera.git", rev = "1e36d2f8ba66833ce9ad2b46044e21f8240b5299", version = "1.20.0" } # Contains custom logic to render variables ignoring unknown variables
 tokio = { version = "1.47.1", features = ["full"] }
 mockall = "0.13.1"
 mockito = "1.7.0"

--- a/crates/oct-cli/Cargo.toml
+++ b/crates/oct-cli/Cargo.toml
@@ -1,7 +1,17 @@
 [package]
 name = "oct-cli"
-version = "0.1.0"
-edition = "2024"
+description = { workspace = true }
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+documentation = { workspace = true }
+categories = { workspace = true }
+keywords = { workspace = true }
+rust-version = { workspace = true }
 
 [dependencies]
 oct-orchestrator = { workspace = true }

--- a/crates/oct-cloud/Cargo.toml
+++ b/crates/oct-cloud/Cargo.toml
@@ -1,7 +1,17 @@
 [package]
 name = "oct-cloud"
-version = "0.1.0"
-edition = "2024"
+description = { workspace = true }
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+documentation = { workspace = true }
+categories = { workspace = true }
+keywords = { workspace = true }
+rust-version = { workspace = true }
 
 [dependencies]
 aws-config = { workspace = true }

--- a/crates/oct-ctl/Cargo.toml
+++ b/crates/oct-ctl/Cargo.toml
@@ -1,7 +1,17 @@
 [package]
 name = "oct-ctl"
-version = "0.1.0"
-edition = "2024"
+description = { workspace = true }
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+documentation = { workspace = true }
+categories = { workspace = true }
+keywords = { workspace = true }
+rust-version = { workspace = true }
 
 [dependencies]
 axum = { workspace = true }

--- a/crates/oct-orchestrator/Cargo.toml
+++ b/crates/oct-orchestrator/Cargo.toml
@@ -1,7 +1,17 @@
 [package]
 name = "oct-orchestrator"
-version = "0.1.0"
-edition = "2024"
+description = { workspace = true }
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+documentation = { workspace = true }
+categories = { workspace = true }
+keywords = { workspace = true }
+rust-version = { workspace = true }
 
 [dependencies]
 oct-cloud = { workspace = true }


### PR DESCRIPTION
To be able to publish `oct-cli`, all dependencies must also be published