### PR TITLE
Remove unsupported `workspace.package.name` field from root `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [workspace.package]
-name = "opencloudtool"
 version = "0.4.1"
 authors = ["opencloudtool Contributors"]
 categories = ["command-line-utilities"]


### PR DESCRIPTION
Fixed warning