### PR TITLE
Remove Code Rabbit from `CODEOWNERS`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence.
-* @minev-dev @andagaev @olegasics @coderabbitai
+* @minev-dev @andagaev @olegasics @coderabbitai[bot]

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence.
-* @minev-dev @andagaev @olegasics @coderabbitai[bot]
+* @minev-dev @andagaev @olegasics


### PR DESCRIPTION
Looks like it's not available now to add bots as code owners https://github.com/orgs/community/discussions/23064