### PR TITLE
Fix clippy errors

### DIFF
--- a/crates/oct-cli/src/main.rs
+++ b/crates/oct-cli/src/main.rs
@@ -64,7 +64,8 @@ mod tests {
     #[tokio::test]
     async fn test_main_deploy_no_oct_toml() {
         // Arrange
-        let mut oct_cli_bin = Command::cargo_bin(assert_cmd::crate_name!()).unwrap();
+        let mut oct_cli_bin =
+            Command::cargo_bin(assert_cmd::crate_name!()).expect("Failed to the binary");
 
         // Act
         let cmd = oct_cli_bin.arg("deploy");
@@ -78,7 +79,8 @@ mod tests {
     #[tokio::test]
     async fn test_main_destroy_no_oct_toml() {
         // Arrange
-        let mut oct_cli_bin = Command::cargo_bin(assert_cmd::crate_name!()).unwrap();
+        let mut oct_cli_bin =
+            Command::cargo_bin(assert_cmd::crate_name!()).expect("Failed to the binary");
 
         // Act
         let cmd = oct_cli_bin.arg("destroy");

--- a/crates/oct-cloud/src/aws/client.rs
+++ b/crates/oct-cloud/src/aws/client.rs
@@ -638,6 +638,15 @@ pub struct Route53Impl {
     inner: aws_sdk_route53::Client,
 }
 
+/// Represents a DNS record.
+///
+/// The tuple contains the following elements in order:
+/// 1. The domain name of the record.
+/// 2. The type of the DNS record (e.g., A, AAAA, CNAME, etc.).
+/// 3. The value of the record (e.g., an IP address).
+/// 4. The time-to-live (TTL) for the record in seconds.
+pub type DnsRecord = (String, RecordType, String, Option<i64>);
+
 #[cfg_attr(test, allow(dead_code))]
 #[cfg_attr(test, automock)]
 impl Route53Impl {
@@ -782,7 +791,7 @@ impl Route53Impl {
     pub async fn get_dns_records(
         &self,
         hosted_zone_id: String,
-    ) -> Result<Vec<(String, RecordType, String, Option<i64>)>, Box<dyn std::error::Error>> {
+    ) -> Result<Vec<DnsRecord>, Box<dyn std::error::Error>> {
         log::info!("Getting DNS records for {hosted_zone_id}");
 
         let response = self

--- a/crates/oct-cloud/src/infra/graph.rs
+++ b/crates/oct-cloud/src/infra/graph.rs
@@ -18,10 +18,10 @@ use crate::infra::resource::{
 };
 
 pub struct GraphManager {
-    ec2_client: client::Ec2,
-    iam_client: client::IAM,
-    ecr_client: client::ECR,
-    route53_client: client::Route53,
+    ec2: client::Ec2,
+    iam: client::IAM,
+    ecr: client::ECR,
+    route53: client::Route53,
 }
 
 impl GraphManager {
@@ -43,10 +43,10 @@ impl GraphManager {
         let route53_client = client::Route53::new(aws_sdk_route53::Client::new(&config));
 
         Self {
-            ec2_client,
-            iam_client,
-            ecr_client,
-            route53_client,
+            ec2: ec2_client,
+            iam: iam_client,
+            ecr: ecr_client,
+            route53: route53_client,
         }
     }
 
@@ -58,10 +58,10 @@ impl GraphManager {
         route53_client: client::Route53,
     ) -> Self {
         Self {
-            ec2_client,
-            iam_client,
-            ecr_client,
-            route53_client,
+            ec2: ec2_client,
+            iam: iam_client,
+            ecr: ecr_client,
+            route53: route53_client,
         }
     }
 
@@ -263,7 +263,7 @@ impl GraphManager {
                 SpecNode::Resource(resource_type) => match resource_type {
                     ResourceSpecType::HostedZone(resource) => {
                         let manager = HostedZoneManager {
-                            client: &self.route53_client,
+                            client: &self.route53,
                         };
                         let output_resource = manager.create(resource, parent_nodes).await;
 
@@ -276,7 +276,7 @@ impl GraphManager {
                     }
                     ResourceSpecType::DnsRecord(resource) => {
                         let manager = DnsRecordManager {
-                            client: &self.route53_client,
+                            client: &self.route53,
                         };
                         let output_resource = manager.create(resource, parent_nodes).await;
 
@@ -288,9 +288,7 @@ impl GraphManager {
                         }
                     }
                     ResourceSpecType::Vpc(resource) => {
-                        let manager = VpcManager {
-                            client: &self.ec2_client,
-                        };
+                        let manager = VpcManager { client: &self.ec2 };
                         let output_vpc = manager.create(resource, parent_nodes).await;
 
                         match output_vpc {
@@ -299,9 +297,7 @@ impl GraphManager {
                         }
                     }
                     ResourceSpecType::InternetGateway(resource) => {
-                        let manager = InternetGatewayManager {
-                            client: &self.ec2_client,
-                        };
+                        let manager = InternetGatewayManager { client: &self.ec2 };
                         let output_igw = manager.create(resource, parent_nodes).await;
 
                         match output_igw {
@@ -312,9 +308,7 @@ impl GraphManager {
                         }
                     }
                     ResourceSpecType::RouteTable(resource) => {
-                        let manager = RouteTableManager {
-                            client: &self.ec2_client,
-                        };
+                        let manager = RouteTableManager { client: &self.ec2 };
                         let output_route_table = manager.create(resource, parent_nodes).await;
 
                         match output_route_table {
@@ -325,9 +319,7 @@ impl GraphManager {
                         }
                     }
                     ResourceSpecType::Subnet(resource) => {
-                        let manager = SubnetManager {
-                            client: &self.ec2_client,
-                        };
+                        let manager = SubnetManager { client: &self.ec2 };
                         let output_subnet = manager.create(resource, parent_nodes).await;
 
                         match output_subnet {
@@ -338,9 +330,7 @@ impl GraphManager {
                         }
                     }
                     ResourceSpecType::SecurityGroup(resource) => {
-                        let manager = SecurityGroupManager {
-                            client: &self.ec2_client,
-                        };
+                        let manager = SecurityGroupManager { client: &self.ec2 };
                         let output_security_group = manager.create(resource, parent_nodes).await;
 
                         match output_security_group {
@@ -351,9 +341,7 @@ impl GraphManager {
                         }
                     }
                     ResourceSpecType::InstanceRole(resource) => {
-                        let manager = InstanceRoleManager {
-                            client: &self.iam_client,
-                        };
+                        let manager = InstanceRoleManager { client: &self.iam };
                         let output_instance_role = manager.create(resource, parent_nodes).await;
 
                         match output_instance_role {
@@ -364,9 +352,7 @@ impl GraphManager {
                         }
                     }
                     ResourceSpecType::InstanceProfile(resource) => {
-                        let manager = InstanceProfileManager {
-                            client: &self.iam_client,
-                        };
+                        let manager = InstanceProfileManager { client: &self.iam };
                         let output_resource = manager.create(resource, parent_nodes).await;
 
                         match output_resource {
@@ -377,9 +363,7 @@ impl GraphManager {
                         }
                     }
                     ResourceSpecType::Ecr(resource) => {
-                        let manager = EcrManager {
-                            client: &self.ecr_client,
-                        };
+                        let manager = EcrManager { client: &self.ecr };
                         let output_resource = manager.create(resource, parent_nodes).await;
 
                         match output_resource {
@@ -392,9 +376,7 @@ impl GraphManager {
                         }
                     }
                     ResourceSpecType::Vm(resource) => {
-                        let manager = VmManager {
-                            client: &self.ec2_client,
-                        };
+                        let manager = VmManager { client: &self.ec2 };
                         let output_vm = manager.create(resource, parent_nodes).await;
 
                         match output_vm {
@@ -497,68 +479,50 @@ impl GraphManager {
                 Node::Resource(resource_type) => match resource_type {
                     ResourceType::HostedZone(resource) => {
                         let manager = HostedZoneManager {
-                            client: &self.route53_client,
+                            client: &self.route53,
                         };
                         manager.destroy(resource, parent_nodes).await
                     }
                     ResourceType::DnsRecord(resource) => {
                         let manager = DnsRecordManager {
-                            client: &self.route53_client,
+                            client: &self.route53,
                         };
                         manager.destroy(resource, parent_nodes).await
                     }
                     ResourceType::Vpc(resource) => {
-                        let manager = VpcManager {
-                            client: &self.ec2_client,
-                        };
+                        let manager = VpcManager { client: &self.ec2 };
                         manager.destroy(resource, parent_nodes).await
                     }
                     ResourceType::InternetGateway(resource) => {
-                        let manager = InternetGatewayManager {
-                            client: &self.ec2_client,
-                        };
+                        let manager = InternetGatewayManager { client: &self.ec2 };
                         manager.destroy(resource, parent_nodes).await
                     }
                     ResourceType::RouteTable(resource) => {
-                        let manager = RouteTableManager {
-                            client: &self.ec2_client,
-                        };
+                        let manager = RouteTableManager { client: &self.ec2 };
                         manager.destroy(resource, parent_nodes).await
                     }
                     ResourceType::Subnet(resource) => {
-                        let manager = SubnetManager {
-                            client: &self.ec2_client,
-                        };
+                        let manager = SubnetManager { client: &self.ec2 };
                         manager.destroy(resource, parent_nodes).await
                     }
                     ResourceType::SecurityGroup(resource) => {
-                        let manager = SecurityGroupManager {
-                            client: &self.ec2_client,
-                        };
+                        let manager = SecurityGroupManager { client: &self.ec2 };
                         manager.destroy(resource, parent_nodes).await
                     }
                     ResourceType::InstanceRole(resource) => {
-                        let manager = InstanceRoleManager {
-                            client: &self.iam_client,
-                        };
+                        let manager = InstanceRoleManager { client: &self.iam };
                         manager.destroy(resource, parent_nodes).await
                     }
                     ResourceType::InstanceProfile(resource) => {
-                        let manager = InstanceProfileManager {
-                            client: &self.iam_client,
-                        };
+                        let manager = InstanceProfileManager { client: &self.iam };
                         manager.destroy(resource, parent_nodes).await
                     }
                     ResourceType::Ecr(resource) => {
-                        let manager = EcrManager {
-                            client: &self.ecr_client,
-                        };
+                        let manager = EcrManager { client: &self.ecr };
                         manager.destroy(resource, parent_nodes).await
                     }
                     ResourceType::Vm(resource) => {
-                        let manager = VmManager {
-                            client: &self.ec2_client,
-                        };
+                        let manager = VmManager { client: &self.ec2 };
                         manager.destroy(resource, parent_nodes).await
                     }
                     ResourceType::None => Err("Unexpected case ResourceType::None".into()),
@@ -678,8 +642,7 @@ mod tests {
         let domain_name = Some(String::from("example.com"));
 
         // Act
-        let graph =
-            GraphManager::get_spec_graph(number_of_instances, &instance_type, domain_name.clone());
+        let graph = GraphManager::get_spec_graph(number_of_instances, &instance_type, domain_name);
 
         // Assert
         let number_of_nodes = 10 + 2 * number_of_instances;
@@ -727,8 +690,7 @@ mod tests {
         let domain_name = Some(String::from("example.com"));
 
         // Act
-        let graph =
-            GraphManager::get_spec_graph(number_of_instances, &instance_type, domain_name.clone());
+        let graph = GraphManager::get_spec_graph(number_of_instances, &instance_type, domain_name);
 
         // Assert
         let number_of_nodes = 10 + 2 * number_of_instances;
@@ -1384,7 +1346,7 @@ aws ecr get-login-password --region us-west-2 | podman login --username AWS --pa
             public_ip: "1.2.3.4".to_string(),
             ami: "ami-04dd23e62ed049936".to_string(),
             instance_type: InstanceType::T2Micro,
-            user_data: "".to_string(), // Not used in destroy
+            user_data: String::new(), // Not used in destroy
         })));
 
         graph.extend_with_edges(&[

--- a/crates/oct-cloud/src/infra/resource.rs
+++ b/crates/oct-cloud/src/infra/resource.rs
@@ -1514,7 +1514,10 @@ mod tests {
 
         // Assert
         assert!(igw.is_err());
-        assert_eq!(igw.unwrap_err().to_string(), "Igw expects VPC as a parent");
+        assert_eq!(
+            igw.expect_err("Expected error").to_string(),
+            "Igw expects VPC as a parent"
+        );
     }
 
     #[tokio::test]
@@ -1595,7 +1598,7 @@ mod tests {
         // Assert
         assert!(result.is_err());
         assert_eq!(
-            result.unwrap_err().to_string(),
+            result.expect_err("Expected error").to_string(),
             "Igw expects VPC as a parent"
         );
     }
@@ -1718,7 +1721,7 @@ mod tests {
         // Assert
         assert!(result.is_err());
         assert_eq!(
-            result.unwrap_err().to_string(),
+            result.expect_err("Expected error").to_string(),
             "Subnet expects VPC as a parent"
         );
     }
@@ -1751,7 +1754,7 @@ mod tests {
         // Assert
         assert!(result.is_err());
         assert_eq!(
-            result.unwrap_err().to_string(),
+            result.expect_err("Expected error").to_string(),
             "Subnet expects RouteTable as a parent"
         );
     }
@@ -1853,7 +1856,7 @@ mod tests {
         // Assert
         assert!(result.is_err());
         assert_eq!(
-            result.unwrap_err().to_string(),
+            result.expect_err("Expected error").to_string(),
             "Subnet expects RouteTable as a parent"
         );
     }
@@ -1958,7 +1961,7 @@ mod tests {
         // Assert
         assert!(result.is_err());
         assert_eq!(
-            result.unwrap_err().to_string(),
+            result.expect_err("Expected error").to_string(),
             "RouteTable expects VPC as a parent"
         );
     }
@@ -1987,7 +1990,7 @@ mod tests {
         // Assert
         assert!(result.is_err());
         assert_eq!(
-            result.unwrap_err().to_string(),
+            result.expect_err("Expected error").to_string(),
             "RouteTable expects IGW as a parent"
         );
     }
@@ -2161,7 +2164,7 @@ mod tests {
         // Assert
         assert!(result.is_err());
         assert_eq!(
-            result.unwrap_err().to_string(),
+            result.expect_err("Expected error").to_string(),
             "DnsRecord expects HostedZone as a parent"
         );
     }
@@ -2192,7 +2195,7 @@ mod tests {
         // Assert
         assert!(result.is_err());
         assert_eq!(
-            result.unwrap_err().to_string(),
+            result.expect_err("Expected error").to_string(),
             "DnsRecord expects Vm as a parent"
         );
     }
@@ -2300,7 +2303,7 @@ mod tests {
         // Assert
         assert!(result.is_err());
         assert_eq!(
-            result.unwrap_err().to_string(),
+            result.expect_err("Expected error").to_string(),
             "DnsRecord expects HostedZone as a parent"
         );
     }
@@ -2422,7 +2425,7 @@ mod tests {
         // Assert
         assert!(result.is_err());
         assert_eq!(
-            result.unwrap_err().to_string(),
+            result.expect_err("Expected error").to_string(),
             "SecurityGroup expects VPC as a parent"
         );
     }
@@ -2806,7 +2809,7 @@ mod tests {
         // Assert
         assert!(result.is_err());
         assert_eq!(
-            result.unwrap_err().to_string(),
+            result.expect_err("Expected error").to_string(),
             "VM expects Subnet as a parent"
         );
     }
@@ -2849,7 +2852,7 @@ mod tests {
         // Assert
         assert!(result.is_err());
         assert_eq!(
-            result.unwrap_err().to_string(),
+            result.expect_err("Expected error").to_string(),
             "VM expects Ecr as a parent"
         );
     }
@@ -2894,7 +2897,7 @@ mod tests {
         // Assert
         assert!(result.is_err());
         assert_eq!(
-            result.unwrap_err().to_string(),
+            result.expect_err("Expected error").to_string(),
             "VM expects InstanceProfile as a parent"
         );
     }
@@ -2937,7 +2940,7 @@ mod tests {
         // Assert
         assert!(result.is_err());
         assert_eq!(
-            result.unwrap_err().to_string(),
+            result.expect_err("Expected error").to_string(),
             "SecurityGroup expects VPC as a parent"
         );
     }

--- a/crates/oct-orchestrator/src/backend.rs
+++ b/crates/oct-orchestrator/src/backend.rs
@@ -167,13 +167,22 @@ mod tests {
     "value": "test"
 }"#;
 
-        let mut file = tempfile::NamedTempFile::new().unwrap();
-        file.write_all(state_file_content.as_bytes()).unwrap();
+        let mut state_file = tempfile::NamedTempFile::new().expect("Failed to create a temp file");
+        state_file
+            .write_all(state_file_content.as_bytes())
+            .expect("Failed to write to file");
 
-        let state_backend = LocalStateBackend::<TestState>::new(file.path().to_str().unwrap());
+        let state_file_path = state_file
+            .path()
+            .to_str()
+            .expect("Failed to convert path to str");
+        let state_backend = LocalStateBackend::<TestState>::new(state_file_path);
 
         // Act
-        let (state, loaded) = state_backend.load().await.unwrap();
+        let (state, loaded) = state_backend
+            .load()
+            .await
+            .expect("Failed to load from state backend");
 
         // Assert
         assert!(loaded);
@@ -191,7 +200,10 @@ mod tests {
         let state_backend = LocalStateBackend::<TestState>::new("NO_FILE");
 
         // Act
-        let (state, loaded) = state_backend.load().await.unwrap();
+        let (state, loaded) = state_backend
+            .load()
+            .await
+            .expect("Failed to load from state backend");
 
         // Assert
         assert_eq!(state.value, "");
@@ -205,16 +217,21 @@ mod tests {
             value: "test".to_string(),
         };
 
-        let state_file = tempfile::NamedTempFile::new().unwrap();
-        let state_file_path = state_file.path().to_str().unwrap();
-
+        let state_file = tempfile::NamedTempFile::new().expect("Failed to create a temp file");
+        let state_file_path = state_file
+            .path()
+            .to_str()
+            .expect("Failed to convert path to str");
         let state_backend = LocalStateBackend::<TestState>::new(state_file_path);
 
         // Act
-        state_backend.save(&state).await.unwrap();
+        state_backend
+            .save(&state)
+            .await
+            .expect("Failed to save to state file");
 
         // Assert
-        let file_content = fs::read_to_string(state_file_path).unwrap();
+        let file_content = fs::read_to_string(state_file_path).expect("Failed to read from file");
 
         assert_eq!(
             file_content,
@@ -239,7 +256,10 @@ mod tests {
 
         let state = TestState::default();
 
-        state_backend.save(&state).await.unwrap();
+        state_backend
+            .save(&state)
+            .await
+            .expect("Failed to save to state file");
     }
 
     #[tokio::test]
@@ -247,6 +267,9 @@ mod tests {
     async fn test_s3_backend_load() {
         let state_backend = S3StateBackend::<TestState>::new("region", "bucket", "key");
 
-        state_backend.load().await.unwrap();
+        let _ = state_backend
+            .load()
+            .await
+            .expect("Failed to load from state backend");
     }
 }

--- a/crates/oct-orchestrator/src/config.rs
+++ b/crates/oct-orchestrator/src/config.rs
@@ -185,11 +185,14 @@ memory = 64
 depends_on = ["app_1"]
 "#;
 
-        let mut file = tempfile::NamedTempFile::new().unwrap();
-        file.write_all(config_file_content.as_bytes()).unwrap();
+        let mut config_file = tempfile::NamedTempFile::new().expect("Failed to create a temp file");
+        config_file
+            .write_all(config_file_content.as_bytes())
+            .expect("Failed to write to file");
 
         // Act
-        let config = Config::new(file.path().to_str()).unwrap();
+        let config =
+            Config::new(config_file.path().to_str()).expect("Failed to create a new config");
 
         // Assert
         assert_eq!(


### PR DESCRIPTION
* Remove `_client` suffix in field names in `GraphManager` 
* Replace `unwrap_err` with `expect_err`
* Replace `unwrap` with `expect`
* Update `oct-py` to use async-aware Mutex from `tokio`
* Add `DnsRecord` inline type to return from `aws::client::get_dns_records`