### PR TITLE
Do not sync tags in Git Town

### DIFF
--- a/.git-town.toml
+++ b/.git-town.toml
@@ -18,7 +18,7 @@ delete-tracking-branch = false
 strategy = "api"
 
 [sync]
-tags = true
+tags = false
 feature-strategy = "rebase"
 perennial-strategy = "rebase"
 prototype-strategy = "rebase"


### PR DESCRIPTION
Fixes:
```
❯ git hack update-issue-templates

[main] git fetch --prune --tags
From github.com:opencloudtool/opencloudtool
 ! [rejected]        tip        -> tip  (would clobber existing tag)

Error: exit status 1
```