### PR TITLE
Remove separate command to build `oct-cli` for tests from postsubmit

### DIFF
--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -83,16 +83,8 @@ jobs:
       - name: Prepare coverage
         run: cargo llvm-cov clean --workspace
 
-      - name: Compile for tests
-        run: cargo test --no-run --locked
-
-      # Binaries needs to be compiled separately because
-      # CLI tests call these binaries.
-      - name: Compile debug binaries for tests
-        run: cargo build --bin oct-cli
-
       - name: Run tests and generate coverage data
-        run: cargo test --no-fail-fast --verbose
+        run: cargo test --no-fail-fast --locked --verbose
 
       - name: Report coverage
         run: cargo llvm-cov report --lcov --output-path ./coverage.lcov


### PR DESCRIPTION
After https://github.com/opencloudtool/opencloudtool/pull/496 the `oct-cli` tests moved to `tests` folder as integration tests. And a new version of `assert_cmd` crate is used which utilizes `CARGO_BIN_EXE_<name>` env var to locate the binary