### PR TITLE
Remove logic to remove/update user services during deployment

### DIFF
--- a/crates/oct-orchestrator/src/scheduler.rs
+++ b/crates/oct-orchestrator/src/scheduler.rs
@@ -92,6 +92,7 @@ impl<'a> Scheduler<'a> {
     }
 
     /// Stops a running container and removes it from the state
+    #[allow(dead_code)]
     pub(crate) async fn stop(
         &mut self,
         service_name: &str,


### PR DESCRIPTION
This logic will be implemented in the follow-up releases, now we care only about creation of user services. For now they cannot be updated and removal happens along with VM.

Closes #501