### PR TITLE
Simplify AWS auth config

### DIFF
--- a/crates/oct-cloud/src/aws/resource.rs
+++ b/crates/oct-cloud/src/aws/resource.rs
@@ -13,11 +13,6 @@ impl S3Bucket {
         // Load AWS configuration
         let region_provider = aws_sdk_s3::config::Region::new(region.clone());
         let config = aws_config::defaults(aws_config::BehaviorVersion::latest())
-            .credentials_provider(
-                aws_config::profile::ProfileFileCredentialsProvider::builder()
-                    .profile_name("default")
-                    .build(),
-            )
             .region(region_provider)
             .load()
             .await;

--- a/crates/oct-cloud/src/infra/graph.rs
+++ b/crates/oct-cloud/src/infra/graph.rs
@@ -28,11 +28,6 @@ impl GraphManager {
     pub async fn new() -> Self {
         let region_provider = aws_sdk_ec2::config::Region::new("us-west-2");
         let config = aws_config::defaults(aws_config::BehaviorVersion::latest())
-            .credentials_provider(
-                aws_config::profile::ProfileFileCredentialsProvider::builder()
-                    .profile_name("default")
-                    .build(),
-            )
             .region(region_provider)
             .load()
             .await;


### PR DESCRIPTION
Explicit `ProfileFileCredentialsProvider` was overriding the default behavior by ignoring instance profile which is used on EC2 instances.

Makes auth code work for both local and EC2 environments.